### PR TITLE
967 Mlukasch treemap list implementation

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -3,7 +3,6 @@
 @table-border-color:            #ddd;
 //** Border color for elements within panels
 @panel-default-heading-bg:    #f5f5f5;
-@font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 
 
 .spaced {
@@ -146,15 +145,16 @@
   // .node.big {
   //   text-indent: 2px;
   // }
+
+  .node:hover {
+    //text-indent: 2px;
+    text-decoration: none;
+  }
 }
 
 
 
 .treemap-list {
-  .node:hover {
-    //text-indent: 2px;
-    text-decoration: none;
-  }
 
   .treemap-table-bar {
     margin-top: 10px;

--- a/less/style.less
+++ b/less/style.less
@@ -155,6 +155,7 @@
 
   .nodetable {
     margin-top: 10px;
+    width:100%;
 
     tr {
       border-top: gray solid medium;

--- a/less/style.less
+++ b/less/style.less
@@ -181,6 +181,10 @@
       font-family: @font-family-monospace;
     }
 
+    tfoot td {
+      font-weight: bolder;
+    }
+
     .colorbox {
       height: 1em;
       width: 1em;

--- a/less/style.less
+++ b/less/style.less
@@ -165,26 +165,6 @@
     width:100%;
     color: #2a2d34;
 
-    &.animate-show {
-      line-height: 2em;
-      opacity: 1;
-      padding: 10px;
-    }
-
-    &.animate-show.ng-hide-add, &.animate-show.ng-hide-remove {
-      -webkit-transition: all linear 0.5s;
-      -moz-transition: all linear 0.5s;
-      -ms-transition: all linear 0.5s;
-      -o-transition: all linear 0.5s;
-      transition: all linear 0.5s;
-    }
-
-    &.animate-show.ng-hide {
-      line-height: 0;
-      opacity: 0;
-      padding: 0 10px;
-    }
-
     tr {
       border-top: 1px solid #ddd;
       line-height: 2em;

--- a/less/style.less
+++ b/less/style.less
@@ -147,7 +147,9 @@
   // .node.big {
   //   text-indent: 2px;
   // }
+}
 
+.treemap-table {
   .node:hover {
     //text-indent: 2px;
     text-decoration: none;

--- a/less/style.less
+++ b/less/style.less
@@ -165,13 +165,24 @@
     width:100%;
     color: #2a2d34;
 
-    transition: opacity 0.6s ease-in-out;
-    line-height: 2;
-    opacity: 1;
+    &.animate-show {
+      line-height: 2em;
+      opacity: 1;
+      padding: 10px;
+    }
 
-    &.ng-hide {
+    &.animate-show.ng-hide-add, &.animate-show.ng-hide-remove {
+      -webkit-transition: all linear 0.5s;
+      -moz-transition: all linear 0.5s;
+      -ms-transition: all linear 0.5s;
+      -o-transition: all linear 0.5s;
+      transition: all linear 0.5s;
+    }
+
+    &.animate-show.ng-hide {
       line-height: 0;
       opacity: 0;
+      padding: 0 10px;
     }
 
     tr {

--- a/less/style.less
+++ b/less/style.less
@@ -3,6 +3,7 @@
 @table-border-color:            #ddd;
 //** Border color for elements within panels
 @panel-default-heading-bg:    #f5f5f5;
+@font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 
 
 .spaced {
@@ -150,6 +151,41 @@
   .node:hover {
     //text-indent: 2px;
     text-decoration: none;
+  }
+
+  .nodetable {
+    margin-top: 10px;
+    width: 100%;
+
+    tr {
+      border-top: gray solid medium;
+      line-height: 2em;
+    }
+
+    tr:hover {
+      background-color: yellow;
+    }
+
+    th {
+      font-weight: bold;
+    }
+
+    td:not(:first-child), th:not(:first-child) {
+      text-align: right;
+      padding-left: 20px;
+    }
+
+    td:not(:first-child){
+      font-family: @font-family-monospace;
+    }
+
+    .colorbox {
+      height: 1em;
+      width: 1em;
+      display: inline-block;
+      margin-right: 0.5em;
+      vertical-align: middle;
+    }
   }
 }
 

--- a/less/style.less
+++ b/less/style.less
@@ -117,6 +117,7 @@
 
 /* Tree maps */
 .treemap-chart {
+  min-height: 1000px;
   overflow: hidden;
 
   .node {

--- a/less/style.less
+++ b/less/style.less
@@ -162,7 +162,7 @@
       line-height: 2em;
     }
 
-    tr:hover {
+    tr:not(:first-child):hover {
       background-color: yellow;
     }
 

--- a/less/style.less
+++ b/less/style.less
@@ -167,8 +167,12 @@
       border-top: black solid medium;
     }
 
-    tbody tr:hover {
+    tbody tr:not(.smallItems):hover {
       background-color: yellow;
+    }
+
+    .smallItems{
+      text-align: right;
     }
 
     th {

--- a/less/style.less
+++ b/less/style.less
@@ -118,7 +118,6 @@
 
 /* Tree maps */
 .treemap-chart {
-  min-height: 500px;
   overflow: hidden;
 
   .node {
@@ -149,13 +148,13 @@
   // }
 }
 
-.treemap-table {
+.treemap-list {
   .node:hover {
     //text-indent: 2px;
     text-decoration: none;
   }
 
-  .nodetable {
+  .treemap-table {
     margin-top: 10px;
     width:100%;
 
@@ -164,7 +163,7 @@
       line-height: 2em;
     }
 
-    tr:not(:first-child):hover {
+    tbody tr:hover {
       background-color: yellow;
     }
 

--- a/less/style.less
+++ b/less/style.less
@@ -157,22 +157,15 @@
   .treemap-table {
     margin-top: 10px;
     width:100%;
+    color: #2a2d34;
 
     tr {
-      border-top: gray solid 1px;
+      border-top: 1px solid #ddd;
       line-height: 2em;
     }
 
     tfoot tr {
-      border-top: black solid medium;
-    }
-
-    tbody tr:not(.smallItems):hover {
-      background-color: yellow;
-    }
-
-    .smallItems{
-      text-align: right;
+      border-top: #ddd solid 2px;
     }
 
     th {
@@ -184,9 +177,15 @@
       padding-left: 20px;
     }
 
-    td:not(:first-child){
-      font-family: @font-family-monospace;
+    tbody tr:hover {
+      background-color: #3a99d9;
+      color: white;
     }
+
+
+    // td:not(:first-child){
+     // font-family: @font-family-monospace;
+    //}
 
     tfoot td {
       font-weight: bolder;

--- a/less/style.less
+++ b/less/style.less
@@ -117,7 +117,7 @@
 
 /* Tree maps */
 .treemap-chart {
-  min-height: 1000px;
+  min-height: 500px;
   overflow: hidden;
 
   .node {
@@ -152,8 +152,6 @@
     text-decoration: none;
   }
 }
-
-
 
 .treemap-list {
 

--- a/less/style.less
+++ b/less/style.less
@@ -159,8 +159,12 @@
     width:100%;
 
     tr {
-      border-top: gray solid medium;
+      border-top: gray solid 1px;
       line-height: 2em;
+    }
+
+    tfoot tr {
+      border-top: black solid medium;
     }
 
     tbody tr:hover {

--- a/less/style.less
+++ b/less/style.less
@@ -148,16 +148,31 @@
   // }
 }
 
+
+
 .treemap-list {
   .node:hover {
     //text-indent: 2px;
     text-decoration: none;
   }
 
-  .treemap-table {
+  .treemap-table-bar {
     margin-top: 10px;
+    text-align: left;
+  }
+
+  .treemap-table {
     width:100%;
     color: #2a2d34;
+
+    transition: opacity 0.6s ease-in-out;
+    line-height: 2;
+    opacity: 1;
+
+    &.ng-hide {
+      line-height: 0;
+      opacity: 0;
+    }
 
     tr {
       border-top: 1px solid #ddd;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
+    "postinstall": "npm run build",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
-    "postinstall":"npm install && npm:prepublish",
+    "postinstall":"npm:prepublish",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
-    "postinstall": "npm run build",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
+    "postinstall":"npm install && npm:prepublish",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
-    "postinstall":"npm:prepublish",
+    "postinstall":"npm run prepublish",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build:dist:min": "webpack --config webpack.config.production.js",
     "build": "npm run build:lib && npm run build:dist && npm run build:dist:min",
     "prepublish": "npm run build",
-    "postinstall":"npm run prepublish",
     "review": "jscs lib test",
     "fix": "jscs lib test --fix",
     "test": "mocha"

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -18,11 +18,6 @@ class TreemapDirective {
             var treeMap = new TreeMapComponent();
             var wrapper = element.find('.treemap-chart')[0];
 
-            treeMap.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
-            treeMap.on('click', (treeMapComponent, item) => {
-              $scope.$emit('treemap-click', treeMapComponent, item);
-            });
-
             $scope.cutoffWarning = false;
             $scope.queryLoaded = true;
 
@@ -43,7 +38,10 @@ class TreemapDirective {
               $scope.treeMapTable.data = root;
               $scope.$apply();
             });
-
+            treeMap.on('click', (treeMapComponent, item) => {
+              $scope.$emit('treemap-click', treeMapComponent, item);
+            });
+            treeMap.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
           }
         }
       }

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -34,12 +34,8 @@ class TreemapDirective {
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
               toggle: function() {
-                var treeMap = $(".treemap-table");
-                if(this.show) {
-                  treeMap.fadeOut();
-                } else {
-                  treeMap.fadeIn();
-                }
+                var treeMapSection = $(".treemap-table");
+                this.show ? treeMapSection.fadeOut() : treeMapSection.fadeIn();
                 this.show = !this.show;
               }
             };

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -28,10 +28,13 @@ class TreemapDirective {
               sortDesc: true,
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
-              toggle: function() {
-                var treeMapSection = $(".treemap-table");
+              toggle: () => {
+                let treeMapSection = $(".treemap-table");
                 this.show ? treeMapSection.fadeOut() : treeMapSection.fadeIn();
                 this.show = !this.show;
+              },
+              selectTableRow: (item) => {
+                $scope.$emit('treemap-click', treeMap, item);
               }
             };
             treeMap.on('dataLoaded', (treeMapComponent, root) => {

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -28,16 +28,12 @@ class TreemapDirective {
 
             // TreeMap-Table:
             $scope.treeMapTable = {
-              show: false,
+              show: true,
               sortAttr: '_percentage',
               sortDesc: true,
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; }
             };
-            treeMap.on('textOverflow', treeMapComponent => {
-              $scope.treeMapTable.show = true;
-              $scope.$apply();
-            });
             treeMap.on('dataLoaded', (treeMapComponent, root) => {
               $scope.treeMapTable.data = root;
               $scope.$apply();

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -34,7 +34,7 @@ class TreemapDirective {
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
               toggle: function() {
-                var treeMapTable = $(".treemap-list");
+                var treeMapTable = $(".treemap-table");
                 this.show ? treeMapTable.fadeOut() : treeMapTable.fadeIn();
                 this.show = !this.show;
               }

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -29,9 +29,10 @@ class TreemapDirective {
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
               toggle: () => {
+                let treeMapTable = $scope.treeMapTable;
                 let treeMapSection = $(".treemap-table");
-                this.show ? treeMapSection.fadeOut() : treeMapSection.fadeIn();
-                this.show = !this.show;
+                treeMapTable.show ? treeMapSection.fadeOut() : treeMapSection.fadeIn();
+                treeMapTable.show = !treeMapTable.show;
               },
               selectTableRow: (item) => {
                 $scope.$emit('treemap-click', treeMap, item);

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -27,15 +27,18 @@ class TreemapDirective {
             $scope.queryLoaded = true;
 
             // TreeMap-Table:
-            $scope.treeMapTable = { show: false };
-            $scope.sortType     = 'value'; // set the default sort type
-            $scope.sortReverse  = true;  // set the default sort order
+            $scope.treeMapTable = {
+              show: false,
+              sortAttr: 'value',
+              sortDesc: true,
+              data: null
+            };
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.treeMapTable.show = true;
               $scope.$apply();
             });
             treeMap.on('dataLoaded', (treeMapComponent, root) => {
-              $scope.treeMapData = root;
+              $scope.treeMapTable.data = root;
               $scope.$apply();
             });
 

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -27,25 +27,12 @@ class TreemapDirective {
             $scope.queryLoaded = true;
 
             // TreeMap-Table:
-            var itemFilter = (item => item._percentage >= 0.02);
             $scope.treeMapTable = {
               show: false,
               sortAttr: '_percentage',
               sortDesc: true,
               data: null,
-              invertSorting: function(){ this.sortDesc = !this.sortDesc; },
-              existSmallItems: false,
-              itemFilter: itemFilter,
-              filterActive: true,
-              activateFilter: function(enable) {
-                if (enable) {
-                  this.filterActive = true;
-                  this.itemFilter = itemFilter;
-                } else {
-                  this.filterActive = false;
-                  this.itemFilter = (item => true);
-                }
-              }
+              invertSorting: function(){ this.sortDesc = !this.sortDesc; }
             };
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.treeMapTable.show = true;
@@ -53,7 +40,6 @@ class TreemapDirective {
             });
             treeMap.on('dataLoaded', (treeMapComponent, root) => {
               $scope.treeMapTable.data = root;
-              $scope.treeMapTable.existSmallItems = !root.children.every(item => item._percentage >= 0.02);
               $scope.$apply();
             });
 

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -27,11 +27,11 @@ class TreemapDirective {
             $scope.queryLoaded = true;
 
             // TreeMap-Table:
-            $scope.showTreeMapTable = false;
+            $scope.treeMapTable = { show: false };
             $scope.sortType     = 'value'; // set the default sort type
             $scope.sortReverse  = true;  // set the default sort order
             treeMap.on('textOverflow', treeMapComponent => {
-              $scope.showTreeMapTable = true;
+              $scope.treeMapTable.show = true;
               $scope.$apply();
             });
             treeMap.on('dataLoaded', (treeMapComponent, root) => {

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -33,8 +33,8 @@ class TreemapDirective {
               sortDesc: true,
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
-              toggle: function($event) {
-                var treeMapTable = $($event.currentTarget).closest(".treemap-list").find(".treemap-table");
+              toggle: function() {
+                var treeMapTable = $(".treemap-list");
                 this.show ? treeMapTable.fadeOut() : treeMapTable.fadeIn();
                 this.show = !this.show;
               }

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -25,6 +25,18 @@ class TreemapDirective {
 
             $scope.cutoffWarning = false;
             $scope.queryLoaded = true;
+
+            // TreeMap-Table:
+            $scope.showTreeMapTable = false;
+            treeMap.on('textOverflow', treeMapComponent => {
+              $scope.showTreeMapTable = true;
+              $scope.$apply();
+            });
+            treeMap.on('dataLoaded', (treeMapComponent, data) => {
+              $scope.treeMapData = data;
+              $scope.$apply();
+            });
+
           }
         }
       }

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -28,12 +28,14 @@ class TreemapDirective {
 
             // TreeMap-Table:
             $scope.showTreeMapTable = false;
+            $scope.sortType     = 'value'; // set the default sort type
+            $scope.sortReverse  = true;  // set the default sort order
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.showTreeMapTable = true;
               $scope.$apply();
             });
-            treeMap.on('dataLoaded', (treeMapComponent, data) => {
-              $scope.treeMapData = data;
+            treeMap.on('dataLoaded', (treeMapComponent, root) => {
+              $scope.treeMapData = root;
               $scope.$apply();
             });
 

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -27,12 +27,25 @@ class TreemapDirective {
             $scope.queryLoaded = true;
 
             // TreeMap-Table:
+            var itemFilter = (item => item._percentage >= 0.02);
             $scope.treeMapTable = {
               show: false,
               sortAttr: '_percentage',
               sortDesc: true,
               data: null,
-              invertSorting: (function(){ this.sortDesc=!this.sortDesc })
+              invertSorting: function(){ this.sortDesc = !this.sortDesc; },
+              existSmallItems: false,
+              itemFilter: itemFilter,
+              filterActive: true,
+              activateFilter: function(enable) {
+                if (enable) {
+                  this.filterActive = true;
+                  this.itemFilter = itemFilter;
+                } else {
+                  this.filterActive = false;
+                  this.itemFilter = (item => true);
+                }
+              }
             };
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.treeMapTable.show = true;
@@ -40,6 +53,7 @@ class TreemapDirective {
             });
             treeMap.on('dataLoaded', (treeMapComponent, root) => {
               $scope.treeMapTable.data = root;
+              $scope.treeMapTable.existSmallItems = !root.children.every(item => item._percentage >= 0.02);
               $scope.$apply();
             });
 

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -32,7 +32,12 @@ class TreemapDirective {
               sortAttr: '_percentage',
               sortDesc: true,
               data: null,
-              invertSorting: function(){ this.sortDesc = !this.sortDesc; }
+              invertSorting: function(){ this.sortDesc = !this.sortDesc; },
+              toggle: function($event) {
+                var treeMapTable = $($event.currentTarget).closest(".treemap-list").find(".treemap-table");
+                this.show ? treeMapTable.fadeOut() : treeMapTable.fadeIn();
+                this.show = !this.show;
+              }
             };
             treeMap.on('dataLoaded', (treeMapComponent, root) => {
               $scope.treeMapTable.data = root;

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -34,8 +34,12 @@ class TreemapDirective {
               data: null,
               invertSorting: function(){ this.sortDesc = !this.sortDesc; },
               toggle: function() {
-                var treeMapTable = $(".treemap-table");
-                this.show ? treeMapTable.fadeOut() : treeMapTable.fadeIn();
+                var treeMap = $(".treemap-table");
+                if(this.show) {
+                  treeMap.fadeOut();
+                } else {
+                  treeMap.fadeIn();
+                }
                 this.show = !this.show;
               }
             };

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -29,10 +29,10 @@ class TreemapDirective {
             // TreeMap-Table:
             $scope.treeMapTable = {
               show: false,
-              sortAttr: 'value',
+              sortAttr: '_percentage',
               sortDesc: true,
               data: null,
-              invertSorting: () => { sortDesc = !sortDesc; }
+              invertSorting: (function(){ this.sortDesc=!this.sortDesc })
             };
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.treeMapTable.show = true;

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -31,7 +31,8 @@ class TreemapDirective {
               show: false,
               sortAttr: 'value',
               sortDesc: true,
-              data: null
+              data: null,
+              invertSorting: () => { sortDesc = !sortDesc; }
             };
             treeMap.on('textOverflow', treeMapComponent => {
               $scope.treeMapTable.show = true;

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -14,11 +14,11 @@
 
 <div class="treemap-list">
   <div class="treemap-table-bar">
-    <a href="#" ng-click="treeMapTable.toggle($event)" ng-show="treeMapTable.show">
+    <a href="#" ng-click="treeMapTable.toggle()" ng-show="treeMapTable.show">
       <span class="fa fa-caret-up"></span>
       Hide list
     </a>
-    <a href="#" ng-click="treeMapTable.toggle($event)" ng-hide="treeMapTable.show">
+    <a href="#" ng-click="treeMapTable.toggle()" ng-hide="treeMapTable.show">
       <span class="fa fa-caret-down"></span>
       Show list
     </a>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -16,17 +16,39 @@
   <table class="nodetable table-striped">
     <thead>
     <tr>
-      <th>title</th>
-      <th>amount</th>
-      <th>share</th>
+      <th>
+        <a href="#" ng-click="sortType = '_name'; sortReverse = !sortReverse">
+          title
+          <span ng-show="sortType == '_name'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = 'value'; sortReverse = !sortReverse">
+          amount
+          <span ng-show="sortType == 'value'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = '_percentage'; sortReverse = !sortReverse">
+          share
+          <span ng-show="sortType == '_percentage'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+        </a>
+      </th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="dataElement in treeMapData" class="datarow">
+    <tr ng-repeat="dataElement in treeMapData.children | orderBy:sortType:sortReverse" class="datarow">
       <td><span class="colorbox" ng-style="{'background-color':dataElement._color}"></span>{{ dataElement._name }}</td>
       <td>{{ dataElement._area_fmt }}</td>
-      <td>{{ (dataElement._percentage * 100).toFixed(2) }}</td>
+      <td>{{ (dataElement._percentage * 100).toFixed(2) }}%</td>
     </tr>
     </tbody>
+    <tfoot>
+      <tr>
+        <td>Total</td>
+        <td>{{ treeMapData.summary_fmt }}</td>
+        <td>100%</td>
+      </tr>
+    </tfoot>
   </table>
 </div>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -37,10 +37,20 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="item in treeMapTable.data.children | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
+    <tr ng-repeat="item in treeMapTable.data.children | filter:treeMapTable.itemFilter  | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
       <td><span class="colorbox" ng-style="{'background-color':item._color}"></span>{{ item._name }}</td>
       <td>{{ item._area_fmt }}</td>
       <td>{{ (item._percentage * 100).toFixed(2) }}%</td>
+    </tr>
+    <tr ng-if="treeMapTable.existSmallItems" class="smallItems">
+      <td colspan="3">
+        <a href="#" ng-click="treeMapTable.activateFilter(false)" ng-show="treeMapTable.filterActive">
+          {{ 'Show small items' }}
+        </a>
+        <a href="#" ng-click="treeMapTable.activateFilter(true)" ng-show="!treeMapTable.filterActive">
+          {{ 'Hide small items' }}
+        </a>
+      </td>
     </tr>
     </tbody>
     <tfoot>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -12,8 +12,18 @@
 
 <div class="treemap-chart"></div>
 
-<div class="treemap-list" ng-if="treeMapTable.show">
-  <table class="treemap-table table-striped">
+<div class="treemap-list">
+  <div class="treemap-table-bar">
+    <a href="#" ng-click="treeMapTable.show=false;" ng-show="treeMapTable.show">
+      <span class="fa fa-caret-up"></span>
+      Hide list
+    </a>
+    <a href="#" ng-click="treeMapTable.show=true;" ng-hide="treeMapTable.show">
+      <span class="fa fa-caret-down"></span>
+      Show list
+    </a>
+  </div>
+  <table class="treemap-table table-striped animate-show" ng-show="treeMapTable.show">
     <thead>
     <tr>
       <th>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -12,8 +12,8 @@
 
 <div class="treemap-chart"></div>
 
-<div class="treemap-table">
-  <table class="nodetable table-striped">
+<div class="treemap-list" ng-if="treeMapTable.show">
+  <table class="treemap-table table-striped">
     <thead>
     <tr>
       <th>
@@ -37,10 +37,10 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="dataElement in treeMapData.children | orderBy:sortType:sortReverse" class="datarow">
-      <td><span class="colorbox" ng-style="{'background-color':dataElement._color}"></span>{{ dataElement._name }}</td>
-      <td>{{ dataElement._area_fmt }}</td>
-      <td>{{ (dataElement._percentage * 100).toFixed(2) }}%</td>
+    <tr ng-repeat="item in treeMapData.children | orderBy:sortType:sortReverse" class="datarow">
+      <td><span class="colorbox" ng-style="{'background-color':item._color}"></span>{{ item._name }}</td>
+      <td>{{ item._area_fmt }}</td>
+      <td>{{ (item._percentage * 100).toFixed(2) }}%</td>
     </tr>
     </tbody>
     <tfoot>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -17,27 +17,27 @@
     <thead>
     <tr>
       <th>
-        <a href="#" ng-click="sortType = '_name'; sortReverse = !sortReverse">
+        <a href="#" ng-click="treeMapTable.sortAttr = '_name'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
           title
-          <span ng-show="sortType == '_name'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+          <span ng-show="treeMapTable.sortAttr == '_name'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
       <th>
-        <a href="#" ng-click="sortType = 'value'; sortReverse = !sortReverse">
+        <a href="#" ng-click="treeMapTable.sortAttr = 'value'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
           amount
-          <span ng-show="sortType == 'value'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+          <span ng-show="sortType == 'value'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
       <th>
-        <a href="#" ng-click="sortType = '_percentage'; sortReverse = !sortReverse">
+        <a href="#" ng-click="treeMapTable.sortAttr = '_percentage'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
           share
-          <span ng-show="sortType == '_percentage'" class="fa" ng-class="sortReverse ? 'fa-caret-up' : 'fa-caret-down'"></span>
+          <span ng-show="treeMapTable.sortAttr == '_percentage'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="item in treeMapData.children | orderBy:sortType:sortReverse" class="datarow">
+    <tr ng-repeat="item in treeMapTable.data.children | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
       <td><span class="colorbox" ng-style="{'background-color':item._color}"></span>{{ item._name }}</td>
       <td>{{ item._area_fmt }}</td>
       <td>{{ (item._percentage * 100).toFixed(2) }}%</td>
@@ -46,7 +46,7 @@
     <tfoot>
       <tr>
         <td>Total</td>
-        <td>{{ treeMapData.summary_fmt }}</td>
+        <td>{{ treeMapTable.data.summary_fmt }}</td>
         <td>100%</td>
       </tr>
     </tfoot>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -25,7 +25,7 @@
       <th>
         <a href="#" ng-click="treeMapTable.sortAttr = 'value'; treeMapTable.invertSorting();">
           amount
-          <span ng-show="sortType == 'value'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
+          <span ng-show="treeMapTable.sortAttr == 'value'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
       <th>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -11,3 +11,22 @@
 </div>
 
 <div class="treemap-chart"></div>
+
+<div class="treemap-table">
+  <table class="nodetable table-striped">
+    <thead>
+    <tr>
+      <th>title</th>
+      <th>amount</th>
+      <th>share</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="dataElement in treeMapData" class="datarow">
+      <td><span class="colorbox" ng-style="{'background-color':dataElement._color}"></span>{{ dataElement._name }}</td>
+      <td>{{ dataElement._area_fmt }}</td>
+      <td>{{ (dataElement._percentage * 100).toFixed(2) }}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -47,7 +47,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="item in treeMapTable.data.children | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
+    <tr ng-repeat="item in treeMapTable.data.children | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow" ng-click="treeMapTable.selectTableRow(item)">
       <td><span class="colorbox" ng-style="{'background-color':item._color}"></span>{{ item._name }}</td>
       <td>{{ item._area_fmt }}</td>
       <td>{{ (item._percentage * 100).toFixed(2) }}%</td>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -14,16 +14,16 @@
 
 <div class="treemap-list">
   <div class="treemap-table-bar">
-    <a href="#" ng-click="treeMapTable.show=false;" ng-show="treeMapTable.show">
+    <a href="#" ng-click="treeMapTable.toggle($event)" ng-show="treeMapTable.show">
       <span class="fa fa-caret-up"></span>
       Hide list
     </a>
-    <a href="#" ng-click="treeMapTable.show=true;" ng-hide="treeMapTable.show">
+    <a href="#" ng-click="treeMapTable.toggle($event)" ng-hide="treeMapTable.show">
       <span class="fa fa-caret-down"></span>
       Show list
     </a>
   </div>
-  <table class="treemap-table table-striped animate-show" ng-show="treeMapTable.show" ng-animate="'treemap-list'">
+  <table class="treemap-table table-striped">
     <thead>
     <tr>
       <th>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -37,20 +37,10 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="item in treeMapTable.data.children | filter:treeMapTable.itemFilter  | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
+    <tr ng-repeat="item in treeMapTable.data.children | orderBy:treeMapTable.sortAttr:treeMapTable.sortDesc" class="datarow">
       <td><span class="colorbox" ng-style="{'background-color':item._color}"></span>{{ item._name }}</td>
       <td>{{ item._area_fmt }}</td>
       <td>{{ (item._percentage * 100).toFixed(2) }}%</td>
-    </tr>
-    <tr ng-if="treeMapTable.existSmallItems" class="smallItems">
-      <td colspan="3">
-        <a href="#" ng-click="treeMapTable.activateFilter(false)" ng-show="treeMapTable.filterActive">
-          {{ 'Show small items' }}
-        </a>
-        <a href="#" ng-click="treeMapTable.activateFilter(true)" ng-show="!treeMapTable.filterActive">
-          {{ 'Hide small items' }}
-        </a>
-      </td>
     </tr>
     </tbody>
     <tfoot>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -17,19 +17,19 @@
     <thead>
     <tr>
       <th>
-        <a href="#" ng-click="treeMapTable.sortAttr = '_name'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
+        <a href="#" ng-click="treeMapTable.sortAttr = '_name'; treeMapTable.invertSorting();">
           title
           <span ng-show="treeMapTable.sortAttr == '_name'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
       <th>
-        <a href="#" ng-click="treeMapTable.sortAttr = 'value'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
+        <a href="#" ng-click="treeMapTable.sortAttr = 'value'; treeMapTable.invertSorting();">
           amount
           <span ng-show="sortType == 'value'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>
       </th>
       <th>
-        <a href="#" ng-click="treeMapTable.sortAttr = '_percentage'; treeMapTable.sortDesc = !treeMapTable.sortDesc">
+        <a href="#" ng-click="treeMapTable.sortAttr = '_percentage'; treeMapTable.invertSorting();">
           share
           <span ng-show="treeMapTable.sortAttr == '_percentage'" class="fa" ng-class="treeMapTable.sortDesc ? 'fa-caret-up' : 'fa-caret-down'"></span>
         </a>

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -23,7 +23,7 @@
       Show list
     </a>
   </div>
-  <table class="treemap-table table-striped animate-show" ng-show="treeMapTable.show">
+  <table class="treemap-table table-striped animate-show" ng-show="treeMapTable.show" ng-animate="'treemap-list'">
     <thead>
     <tr>
       <th>

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -132,7 +132,7 @@ export class TreeMapComponent extends events.EventEmitter {
             if (d._percentage < 0.02) {
               return '';
             }
-            let name = d.href ? `<a href="${d.href}">${d._name}</a>` : d._name;
+            let name = d.href ? `<a href=\"${d.href}\">${d._name}</a>` : d._name;
 
             return d.children ? null : `<td><span>${name}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
           }).select("td")

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -132,8 +132,9 @@ export class TreeMapComponent extends events.EventEmitter {
             if (d._percentage < 0.02) {
               return '';
             }
+            let name = d.href ? `<a href="${d.href}">${d._name}</a>` : d._name;
 
-            return d.children ? null : `<td><span>${d._name}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
+            return d.children ? null : `<td><span>${name}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
           }).select("td")
           .insert("span", ":first-child")
           .style("background", function(d) { return d._color; })

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -109,8 +109,7 @@ export class TreeMapComponent extends events.EventEmitter {
 
     var listdiv = d3.select(wrapper).append("div")
         .style("position", "relative")
-        .style("width", size.width + "px")
-        .style("height", size.height + "px");
+        .style("width", size.width + "px");
 
     // Check & Remove all rectangles with text overlfow:
     var boxContentRemover = (item => $(item).empty());
@@ -130,9 +129,9 @@ export class TreeMapComponent extends events.EventEmitter {
           .append("tr")
           .attr("class","datarow")
           .html(function(d){
-            //if (d._percentage < 0.02) {
-            //return '';
-            //}
+            if (d._percentage < 0.02) {
+              return '';
+            }
 
             return d.children ? null : `<td><span>${d._name}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
           }).select("td")

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -81,8 +81,6 @@ export class TreeMapComponent extends events.EventEmitter {
         root.children.push(cell);
       }
 
-      that.emit('dataLoaded', that, root);
-
       var node = div.datum(root).selectAll(".node")
         .data(that.treemap.nodes)
         .enter().append("a")
@@ -120,7 +118,9 @@ export class TreeMapComponent extends events.EventEmitter {
       if(hasTextOverflow) {
         that.emit('textOverflow', that);
       };
-      that.emit('endAggregate', that, data);
+
+      this.emit('dataLoaded', that, root);
+      this.emit('endAggregate', that, data);
     });
   }
 }

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -15,10 +15,10 @@ function positionNode() {
       return d.y + "px";
     })
     .style("width", (d) => {
-      return Math.max(0, d.dx - 1) + "px"
+      return Math.max(0, d.dx - 1) + "px";
     })
     .style("height", (d) => {
-      return Math.max(0, d.dy - 1) + "px"
+      return Math.max(0, d.dy - 1) + "px";
     });
 };
 
@@ -109,8 +109,8 @@ export class TreeMapComponent extends events.EventEmitter {
 
     // Check & Remove all rectangles with text overlfow:
     var boxContentRemover = (item => $(item).empty());
-    var hasTextOverlow = TreemapUtils.checkForTextOverflow("a.node", boxContentRemover);
-    if(hasTextOverlow) {
+    var hasTextOverflow = TreemapUtils.checkForTextOverflow("a.node", boxContentRemover);
+    if(hasTextOverflow) {
       var listdiv = d3.select(wrapper).append("div")
           .style("position", "relative")
           .style("width", size.width + "px");

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -60,7 +60,9 @@ export class TreeMapComponent extends events.EventEmitter {
 
     api.aggregate(endpoint, cube, params).then((data) => {
       var root = {
-        children: []
+        children: [],
+        summary: data.summary[params.aggregates],
+        summary_fmt: Utils.numberFormat(data.summary[params.aggregates])
       };
 
       for (var i in data.cells) {
@@ -73,13 +75,13 @@ export class TreeMapComponent extends events.EventEmitter {
         cell._name = dimension.nameValue;
         cell._color = Utils.colorScale(i, colorSchema);
 
-        cell._percentage = (data.summary && measure.value && measure.key)
-            ? (measure.value / Math.max(data.summary[measure.key], 1))
+        cell._percentage = (measure.value && data.summary && params.aggregates)
+            ? (measure.value / Math.max(data.summary[params.aggregates], 1))
             : 1;
         root.children.push(cell);
       }
 
-      that.emit('dataLoaded', that, root.children);
+      that.emit('dataLoaded', that, root);
 
       var node = div.datum(root).selectAll(".node")
         .data(that.treemap.nodes)

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -107,14 +107,14 @@ export class TreeMapComponent extends events.EventEmitter {
         .delay(function(d, i) { return Math.min(i * 30, 1500); })
         .style("background", function(d) { return d._color; });
 
-    var listdiv = d3.select(wrapper).append("div")
-        .style("position", "relative")
-        .style("width", size.width + "px");
-
     // Check & Remove all rectangles with text overlfow:
     var boxContentRemover = (item => $(item).empty());
     var hasTextOverlow = TreemapUtils.checkForTextOverflow("a.node", boxContentRemover);
     if(hasTextOverlow) {
+      var listdiv = d3.select(wrapper).append("div")
+          .style("position", "relative")
+          .style("width", size.width + "px");
+
       // Add treemap list:
       var nodetable = listdiv.datum(root)
           .append("table")

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -77,7 +77,7 @@ export class TreeMapComponent extends events.EventEmitter {
 
         cell._percentage = (measure.value && data.summary && params.aggregates)
             ? (measure.value / Math.max(data.summary[params.aggregates], 1))
-            : 1;
+            : 0;
         root.children.push(cell);
       }
 

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -119,26 +119,37 @@ export class TreeMapComponent extends events.EventEmitter {
       var nodetable = listdiv.datum(root)
           .append("table")
           .attr("class", "nodetable");
-      nodetable.append("tr").html("<th>title</th><th>amount</th><th>share</th>");
-      nodetable
+      let nodeheader = nodetable.append("tr").html("<th>title</th><th>amount</th><th>share</th>");
+      let noderows = nodetable
           .selectAll(".datarow")
           .data(that.treemap.nodes.sort(function(x, y){
             return x._percentage < y._percentage;
           }))
           .enter()
           .append("tr")
-          .attr("class","datarow")
+          .attr("class","datarow");
+
+      noderows.selectAll("tr")
           .html(function(d){
             if (d._percentage < 0.02) {
               return '';
             }
-            let name = d.href ? `<a href=\"${d.href}\">${d._name}</a>` : d._name;
+            let name_href = d.href ? `<a href=\"${d.href}\">${d._name}</a>` : d._name;
 
-            return d.children ? null : `<td><span>${name}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
+            return d.children ? null : `<td><span>${name_href}</span></td><td>${d._area_fmt}</td><td>${(d._percentage *100).toFixed(2)}%</td>`;
           }).select("td")
           .insert("span", ":first-child")
           .style("background", function(d) { return d._color; })
           .attr("class", "colorbox");
+
+      // Add sort functionality:
+      let mapping = {"title":"_name", "amount":"_area_fmt", "share":"_percentage"};
+      nodeheader.selectAll("td").data(that.treemap.nodes).on("click", function(selection){
+        that.treemap.nodes.sort(function(x,y){
+            let attribute = mapping[selection];
+            return x[attribute] < y[attribute];
+          });
+      });
     }
     
     this.emit('endAggregate', that, data);

--- a/src/components/treemap/utils.js
+++ b/src/components/treemap/utils.js
@@ -3,10 +3,9 @@
  */
 module.exports.checkForTextOverflow = function(selector, textOverflowHandler){
     var result = false;
-    var rectangles = $(selector);
-    rectangles.each(function(index, item){
+    var elementsForTextOverflowCheck = $(selector);
+    elementsForTextOverflowCheck.each(function(index, item){
         if(($(item)[0].offsetWidth < $(item)[0].scrollWidth) || ($(item)[0].offsetHeight < $(item)[0].scrollHeight)){
-            $(item).empty();
             textOverflowHandler(item);
             result = true;
         }

--- a/src/components/treemap/utils.js
+++ b/src/components/treemap/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Created by maik on 18.05.16.
+ */
+module.exports.checkForTextOverflow = function(selector, textOverflowHandler){
+    var result = false;
+    var rectangles = $(selector);
+    rectangles.each(function(index, item){
+        if($(item)[0].offsetWidth < $(item)[0].scrollWidth){
+            $(item).empty();
+            textOverflowHandler(item);
+            result = true;
+        }
+    });
+    return result;
+};

--- a/src/components/treemap/utils.js
+++ b/src/components/treemap/utils.js
@@ -5,7 +5,7 @@ module.exports.checkForTextOverflow = function(selector, textOverflowHandler){
     var result = false;
     var rectangles = $(selector);
     rectangles.each(function(index, item){
-        if($(item)[0].offsetWidth < $(item)[0].scrollWidth){
+        if(($(item)[0].offsetWidth < $(item)[0].scrollWidth) || ($(item)[0].offsetHeight < $(item)[0].scrollHeight)){
             $(item).empty();
             textOverflowHandler(item);
             result = true;


### PR DESCRIPTION

![treemapsolution](https://cloud.githubusercontent.com/assets/17597578/15361172/c72ad352-1d10-11e6-86cf-689bb16899a2.PNG)
The treemap list only shows up, if there is any text-overflow in one of the treemap boxes.
Also the content of the box is cleared, if there is any text overflow in the box.
Everything below 2% is ignored in the treemap-boxes & treemap-list.
Just for test reason in the Picture above also entries are shown below 2%. But in the delivered Version it is not the case anymore.
I didnt know if I should have used any specific table component for the treemap list.
So atm just used a plain HTML-Table with iterating the rows via D3js.
So the treemap-list has no sort-functionality...
Also zooming in the browser does not work well with the implemented treemap-list.