### PR TITLE
Allow to use external downloader

### DIFF
--- a/src/api/downloader.js
+++ b/src/api/downloader.js
@@ -1,0 +1,50 @@
+import 'isomorphic-fetch'
+import Promise from 'bluebird'
+
+var defaultDownloader = null;
+
+export function getDefaultDownloader() {
+  if (!defaultDownloader) {
+    defaultDownloader = new Downloader();
+  }
+  return defaultDownloader;
+}
+
+export class Downloader {
+  constructor() {
+    this.cache = {};
+  }
+
+  get(url) {
+    var that = this;
+    if (this.cache[url]) {
+      return Promise.resolve(this.cache[url]);
+    } else {
+      return fetch(url).then(function(response) {
+        if (response.status >= 400) {
+          return Promise.reject(new Error(`
+            code: ${response.status},
+            message: ${response.statusText}
+          `));
+        } else {
+          return response.text()
+        }
+      }).then(function(text) {
+        return that.cache[url] = text
+      }).catch(Promise.reject);
+    }
+  }
+
+  getJson(url) {
+    return this.get(url)
+      .then(JSON.parse)
+      .catch(function(err) {
+        console.error("getJson:", err)
+      });
+  }
+
+  flush() {
+    this.cache = {}
+  }
+
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,40 +1,26 @@
-import 'isomorphic-fetch'
 import _ from 'lodash'
-import Promise from 'bluebird'
 import querystring from 'querystring'
 import url from 'url'
+import { getDefaultDownloader } from './downloader'
 
 export class Api {
   constructor() {
-    this.cache = {};
+    this.downloader = null;
   }
 
   get(url) {
-    var that = this;
-    if (this.cache[url]) {
-      return Promise.resolve(this.cache[url]);
-    } else {
-      return fetch(url).then(function(response) {
-        if (response.status >= 400) {
-          return Promise.reject(new Error(`
-            code: ${response.status},
-            message: ${response.statusText}
-          `));
-        } else {
-          return response.text()
-        }
-      }).then(function(text) {
-        return that.cache[url] = text
-      }).catch(Promise.reject);
-    }
+    var downloader = this.downloader || getDefaultDownloader();
+    return downloader.get(url);
   }
 
   getJson(url) {
-    return this.get(url).then(JSON.parse).catch(function(err) { console.error("getJson:", err)});
+    var downloader = this.downloader || getDefaultDownloader();
+    return downloader.getJson(url);
   }
 
   flush() {
-    this.cache = {}
+    var downloader = this.downloader || getDefaultDownloader();
+    return downloader.flush();
   }
 
   transformParams(params) {

--- a/src/bindings/angular/bubbletree/index.js
+++ b/src/bindings/angular/bubbletree/index.js
@@ -3,15 +3,15 @@ import BubbleTreeComponent from '../../../components/bubbletree'
 export class BubbleTreeDirective {
   init(angularModule) {
     angularModule.directive('bubbletree', [
-      '$window',
-      function($window) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
             type: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -19,6 +19,7 @@ export class BubbleTreeDirective {
             var bubbleTree = new BubbleTreeComponent();
             var wrapper = element.find('.bubbletree')[0];
 
+            bubbleTree.downloader = $scope.downloader;
             bubbleTree.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
             bubbleTree.on('click', (bubbleTreeComponent, item) => {
               $scope.$emit('bubbletree-click', bubbleTreeComponent, item);

--- a/src/bindings/angular/chart/index.js
+++ b/src/bindings/angular/chart/index.js
@@ -11,7 +11,8 @@ export class ChartDirective {
             endpoint: '@',
             cube: '@',
             type: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -19,6 +20,7 @@ export class ChartDirective {
             var chart = new ChartComponent();
             var wrapper = element.find('.chart-babbage')[0];
 
+            chart.downloader = $scope.downloader;
             chart.build($scope.type, $scope.endpoint, $scope.cube, $scope.state, wrapper);
 
             $scope.cutoffWarning = false;

--- a/src/bindings/angular/facts/index.js
+++ b/src/bindings/angular/facts/index.js
@@ -10,13 +10,15 @@ export class FactsDirective {
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
-          link: function($scope, element) {
+          link: function($scope) {
             function update() {
               $q((resolve, reject) => {
+                facts.downloader = $scope.downloader;
                 facts.getTableData($scope.endpoint, $scope.cube, $scope.state)
                   .then(resolve)
                   .catch(reject)

--- a/src/bindings/angular/geoview/index.js
+++ b/src/bindings/angular/geoview/index.js
@@ -18,15 +18,17 @@ export class GeoViewDirective {
             state: '=',
             countryCode: '@',
             currencySign: '@?',
+            downloader: '=?'
           },
           template: '<geoview class="geoview-container" country-code="{{ countryCode }}" ' +
           'currency-sign="{{ currencySign }}" cosmo-endpoint="{{ cosmoEndpoint }}" ' +
           'values="values"></geoview>',
           replace: false,
-          link: function($scope, element) {
+          link: function($scope) {
             var geoView = new GeoViewComponent();
 
             $q((resolve, reject) => {
+              geoView.downloader = $scope.downloader;
               geoView.getGeoMapData(
                 $scope.endpoint,
                 $scope.cube,

--- a/src/bindings/angular/pie/index.js
+++ b/src/bindings/angular/pie/index.js
@@ -3,14 +3,14 @@ import PieChartComponent from '../../../components/pie'
 export class PieChartDirective {
   init(angularModule) {
     angularModule.directive('pieChart', [
-      '$window',
-      function($window) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -18,6 +18,7 @@ export class PieChartDirective {
             var pieChart = new PieChartComponent();
             var wrapper = element.find('.pie-chart')[0];
 
+            pieChart.downloader = $scope.downloader;
             pieChart.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
 
             $scope.cutoffWarning = false;

--- a/src/bindings/angular/pivottable/index.js
+++ b/src/bindings/angular/pivottable/index.js
@@ -4,14 +4,14 @@ import PivotTable from 'pivottable'
 export class PivotTableDirective {
   init(angularModule) {
     angularModule.directive('pivotTable', [
-      '$timeout', '$q',
-      function($timeout, $q) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -22,6 +22,7 @@ export class PivotTableDirective {
             var intFormat = numberFormat({digitsAfterDecimal: 0});
 
             var wrapper = element.find('.pivot-table')[0];
+            pivotTableComponent.downloader = $scope.downloader;
             pivotTableComponent.getPivotData($scope.endpoint, $scope.cube, $scope.state).then((result) => {
               $(wrapper).pivot(
                 result.data,

--- a/src/bindings/angular/radar/index.js
+++ b/src/bindings/angular/radar/index.js
@@ -3,22 +3,22 @@ import RadarChartComponent from '../../../components/radar'
 export class RadarChartDirective {
   init(angularModule) {
     angularModule.directive('radarChart', [
-      '$window',
-      function($window) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
           link: function($scope, element) {
             var radarChart = new RadarChartComponent();
             var wrapper = element.find('.radar-chart')[0];
+            radarChart.downloader = $scope.downloader;
             radarChart.getPivotData($scope.endpoint, $scope.cube, $scope.state).then((result) => {
-
               radarChart.build($scope.endpoint, $scope.cube, $scope.state, wrapper, result);
             });
 

--- a/src/bindings/angular/sankey/index.js
+++ b/src/bindings/angular/sankey/index.js
@@ -3,14 +3,14 @@ import SanKeyChartComponent from '../../../components/sankey'
 export class SanKeyChartDirective {
   init(angularModule) {
     angularModule.directive('sanKeyChart', [
-      '$window',
-      function($window) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -21,6 +21,7 @@ export class SanKeyChartDirective {
             $scope.cutoffWarning = false;
             $scope.queryLoaded = true;
 
+            sanKeyChart.downloader = $scope.downloader;
             sanKeyChart.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
 
             sanKeyChart.on('click', (sankeyComponent, item) => {

--- a/src/bindings/angular/table/index.js
+++ b/src/bindings/angular/table/index.js
@@ -3,21 +3,23 @@ import TableComponent from '../../../components/table'
 export class BabbageTableDirective {
   init(angularModule) {
     angularModule.directive('babbageTable', [
-      '$timeout', '$q',
-      function($timeout, $q) {
+      '$q',
+      function($q) {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
-          link: function($scope, element) {
+          link: function($scope) {
             var babbageTable = new TableComponent();
 
             $q((resolve, reject) => {
+              babbageTable.downloader = $scope.downloader;
               babbageTable.getTableData($scope.endpoint, $scope.cube, $scope.state)
                 .then(resolve)
                 .catch(reject)

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -3,14 +3,14 @@ import TreeMapComponent from '../../../components/treemap'
 class TreemapDirective {
   init(angularModule) {
     angularModule.directive('treeMap', [
-      '$window',
-      function($window) {
+      function() {
         return {
           restrict: 'EA',
           scope: {
             endpoint: '@',
             cube: '@',
-            state: '='
+            state: '=',
+            downloader: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -45,6 +45,7 @@ class TreemapDirective {
             treeMap.on('click', (treeMapComponent, item) => {
               $scope.$emit('treemap-click', treeMapComponent, item);
             });
+            treeMap.downloader = $scope.downloader;
             treeMap.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
           }
         }

--- a/src/components/bubbletree/index.js
+++ b/src/components/bubbletree/index.js
@@ -14,6 +14,7 @@ export class BubbleTreeComponent extends events.EventEmitter {
     super();
     this.wrapper = null;
     this.bubbleTree = null;
+    this.downloader = null;
   }
 
   generateBubbuleTreeData (cells, params) {
@@ -45,6 +46,7 @@ export class BubbleTreeComponent extends events.EventEmitter {
 
     this.emit('beginAggregate', this);
 
+    api.downloader = this.downloader;
     api.aggregate(endpoint, cube, params).then((data) => {
       var bubbleTreeData = this.generateBubbuleTreeData(
         data.cells,

--- a/src/components/chart/index.js
+++ b/src/components/chart/index.js
@@ -12,6 +12,7 @@ export class ChartComponent extends events.EventEmitter {
     super();
     this.wrapper = null;
     this.chart = null;
+    this.downloader = null;
   }
 
   build(chartType, endpoint, cube, params, wrapper, colorSchema) {
@@ -45,6 +46,7 @@ export class ChartComponent extends events.EventEmitter {
     params.page = 0;
     params.pagesize = 2000;
 
+    api.downloader = this.downloader;
     api.aggregate(endpoint, cube, params).then((data) => {
 
         var columns = Utils.buildC3Columns(data, groupFields, series, params.aggregates);

--- a/src/components/facts/index.js
+++ b/src/components/facts/index.js
@@ -6,12 +6,14 @@ var api = new Api();
 export class FactsComponent extends events.EventEmitter {
   constructor() {
     super();
+    this.downloader = null;
   }
   getTableData(endpoint, cube, params) {
     params = _.cloneDeep(params);
     var that = this;
 
     this.emit('beginFacts', this);
+      api.downloader = this.downloader;
       return api.facts(endpoint, cube, params).then((data) => {
         this.emit('endFacts', that, data);
         return data;

--- a/src/components/geoview/index.js
+++ b/src/components/geoview/index.js
@@ -6,6 +6,7 @@ var api = new Api();
 export class GeoViewComponent extends events.EventEmitter {
   constructor() {
     super();
+    this.downloader = null;
   }
 
   getGeoMapData(endpoint, cube, params) {
@@ -16,6 +17,7 @@ export class GeoViewComponent extends events.EventEmitter {
 
     this.emit('beginAggregate', this);
 
+    api.downloader = this.downloader;
     return api.aggregate(endpoint, cube, params).then((data) => {
         _.each(data.cells, (cell) => {
           var dimension = _.first(cell.dimensions);

--- a/src/components/pie/index.js
+++ b/src/components/pie/index.js
@@ -11,6 +11,7 @@ export class PieChartComponent extends events.EventEmitter {
     super();
     this.wrapper = null;
     this.chart = null;
+    this.downloader = null;
   }
 
   build(endpoint, cube, params, wrapper, colorSchema) {
@@ -21,6 +22,7 @@ export class PieChartComponent extends events.EventEmitter {
 
     this.emit('beginAggregate', this);
 
+    api.downloader = this.downloader;
     api.aggregate(endpoint, cube, params).then((data) => {
 
       var columns = Utils.buildC3PieColumns(data, params.aggregates);

--- a/src/components/pivottable/index.js
+++ b/src/components/pivottable/index.js
@@ -6,6 +6,7 @@ var api = new Api();
 export class PivotTableComponent extends events.EventEmitter {
   constructor() {
     super();
+    this.downloader = null;
   }
 
   getPivotData(endpoint, cube, params) {
@@ -24,6 +25,7 @@ export class PivotTableComponent extends events.EventEmitter {
     var measures = {};
     var dimensions = [];
 
+    api.downloader = this.downloader;
     return api.getDimensions(endpoint, cube)
       .then((result) => {
         dimensions = {};
@@ -31,6 +33,7 @@ export class PivotTableComponent extends events.EventEmitter {
           dimensions[item.key] = item.code;
         });
 
+        api.downloader = this.downloader;
         return api.getMeasures(endpoint, cube);
       })
       .then((result) => {
@@ -42,6 +45,7 @@ export class PivotTableComponent extends events.EventEmitter {
         params.page = 0;
         params.pagesize = 2000;
 
+        api.downloader = this.downloader;
         return api.aggregate(endpoint, cube, params)
       })
       .then((data) => {

--- a/src/components/radar/index.js
+++ b/src/components/radar/index.js
@@ -9,6 +9,7 @@ export class RadarChartComponent extends events.EventEmitter {
     constructor() {
         super();
         this.wrapper = null;
+        this.downloader = null;
     }
 
     getPivotData(endpoint, cube, params) {
@@ -27,6 +28,7 @@ export class RadarChartComponent extends events.EventEmitter {
         var measures = {};
         var dimensions = [];
 
+        api.downloader = this.downloader;
         return api.getDimensions(endpoint, cube)
             .then((result) => {
                 dimensions = {};
@@ -38,6 +40,7 @@ export class RadarChartComponent extends events.EventEmitter {
 
                 });
 
+                api.downloader = this.downloader;
                 return api.getMeasures(endpoint, cube);
             })
             .then((result) => {
@@ -48,6 +51,7 @@ export class RadarChartComponent extends events.EventEmitter {
 
                 params.page = 0;
                 params.pagesize = 2000;
+                api.downloader = this.downloader;
                 return api.aggregate(endpoint, cube, params)
             })
             .then((data) => {

--- a/src/components/sankey/index.js
+++ b/src/components/sankey/index.js
@@ -11,6 +11,7 @@ export class SanKeyChartComponent extends events.EventEmitter {
     super();
     this.wrapper = null;
     this.sankey = null;
+    this.downloader = null;
   }
 
   build(endpoint, cube, params, wrapper, colorSchema) {
@@ -54,6 +55,7 @@ export class SanKeyChartComponent extends events.EventEmitter {
         .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
     }
 
+    api.downloader = this.downloader;
     api.aggregate(endpoint, cube, params).then((data) => {
 
       size.height = data.cells.length * unit;

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -6,6 +6,7 @@ var api = new Api();
 export class TableComponent extends events.EventEmitter {
   constructor() {
     super();
+    this.downloader = null;
   }
 
   showKeys(items) {
@@ -49,15 +50,18 @@ export class TableComponent extends events.EventEmitter {
     var measures = {};
     var dimensions = [];
 
+    api.downloader = this.downloader;
     return api.getDimensions(endpoint, cube)
       .then((result) => {
         dimensions = result;
 
+        api.downloader = this.downloader;
         return api.getMeasures(endpoint, cube);
       })
       .then((result) => {
         measures = result;
 
+        api.downloader = this.downloader;
         return api.aggregate(endpoint, cube, params)
       })
       .then((data) => {

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -20,13 +20,14 @@ function positionNode() {
     .style("height", (d) => {
       return Math.max(0, d.dy - 1) + "px";
     });
-};
+}
 
 export class TreeMapComponent extends events.EventEmitter {
   constructor() {
     super();
     this.wrapper = null;
     this.treemap = null;
+    this.downloader = null;
   }
 
   build(endpoint, cube, params, wrapper, colorSchema) {
@@ -58,6 +59,7 @@ export class TreeMapComponent extends events.EventEmitter {
       .style("height", size.height + "px");
 
 
+    api.downloader = this.downloader;
     api.aggregate(endpoint, cube, params).then((data) => {
       var root = {};
       root.children = [];


### PR DESCRIPTION
Currently each component has its own `Api` instance with its own query cache. This update allows to specify external downloader object (that should have the same prototype as `Downloader` class from `/src/api/downloader.js`), and have other caching strategy (for example, disable cache at all, or share cache within entire application, etc.)