### PR TITLE
Support cases where measure label is different from measure ref

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -294,7 +294,7 @@ export class Api {
         };
 
         _.each(measures, (measure) => {
-          let measureModel = _.find(measureModelList, {'label': measure.value});
+          let measureModel = _.find(measureModelList, {'ref': measure.value});
           result.summary[measure.key] = data.summary[measure.key];
           result.currency[measure.key] = measureModel["currency"];
         });


### PR DESCRIPTION
This solves the issue that measureModel is undefined because measure label is different from measure ref
