### PR TITLE
[#1199] Improve Sankey labels

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -220,7 +220,6 @@
 
     .node text {
       pointer-events: none;
-      text-shadow: 0 1px 0 #fff;
       font-family: inherit;
     }
 

--- a/src/components/sankey/index.js
+++ b/src/components/sankey/index.js
@@ -16,6 +16,8 @@ export class SanKeyChartComponent extends events.EventEmitter {
     this.downloader = null;
     this.formatValue = null;
 
+    this.CHAR_WIDTH = 10;
+
     // Prevent from throwing exception in EventEmitter
     this.on('error', (sender, error) => {
       console.trace(error);
@@ -210,6 +212,25 @@ export class SanKeyChartComponent extends events.EventEmitter {
             return d.name + '\n' + valueFormat(d.value);
           });
 
+        // Add values inside nodes
+        node.filter(function(d) {
+            // Ignore small nodes
+            var estimatedTextWidth = (valueFormat(d.value).length * that.CHAR_WIDTH);
+            return d.dy > estimatedTextWidth;
+          })
+          .append('text')
+            .attr('class', 'nodeValue')
+	          .text(function (d) { return valueFormat(d.value); })
+	          .attr('text-anchor', 'middle')
+            .attr('transform', function (d) {
+              return 'rotate(-90) translate(' +
+                (-d.dy / 2) +
+                ', ' +
+                (sankey.nodeWidth() / 2 + 5) +
+                ')';
+            });
+
+        // Add labels inside links
         node.append('text')
           .attr('x', -6)
           .attr('y', function(d) {

--- a/src/components/sankey/index.js
+++ b/src/components/sankey/index.js
@@ -207,7 +207,7 @@ export class SanKeyChartComponent extends events.EventEmitter {
           })
           .append('title')
           .text(function(d) {
-            return d.name
+            return d.name + '\n' + valueFormat(d.value);
           });
 
         node.append('text')


### PR DESCRIPTION
Please check the commit messages. This pull request turns this:

![Before](https://cloud.githubusercontent.com/assets/76945/25897447/e68d95c6-357f-11e7-8a2d-aad0e52be400.png)

Into this:
![After](https://cloud.githubusercontent.com/assets/76945/25897449/e7fe86a4-357f-11e7-8901-491d721364b7.png)

Fixes openspending/openspending#1199