### PR TITLE
Add stroke to Pie and Bubble chart's labels

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -305,3 +305,25 @@
     height: 100%;
   }
 }
+
+.pie-chart {
+  .c3-chart-arc text {
+    .text-stroke();
+    fill: #FFF;
+  }
+}
+
+.bubbletree {
+  .bubbletree-label {
+    .text-stroke();
+    fill: #FFF;
+  }
+}
+
+.text-stroke(@colour: #333, @width: 1px) {
+  text-shadow:
+    -@width -@width 0 @colour,
+     @width -@width 0 @colour,
+    -@width  @width 0 @colour,
+     @width  @width 0 @colour;
+}


### PR DESCRIPTION
The labels can overflow outside of the chart. Our options were to either pick a
text colour that is legible in all our background's colours, or use a stroke.
I preferred to use a stroke, as it guarantees that the text will always be
visible, regardless of the background.

![Pie and bubble chart with text stroke](https://cloud.githubusercontent.com/assets/76945/25898692/19c38b26-3585-11e7-8d54-cb4eb077e78c.png)
