### PR TITLE
Allow custom color schemas

### DIFF
--- a/src/bindings/angular/chart/index.js
+++ b/src/bindings/angular/chart/index.js
@@ -16,7 +16,8 @@ export class ChartDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            colorScale: '&',
           },
           template: require('./template.html'),
           replace: false,
@@ -60,8 +61,15 @@ export class ChartDirective {
 
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
-            component.build($scope.type, $scope.endpoint,
-              $scope.cube, $scope.state, wrapper);
+
+            component.build(
+              $scope.type,
+              $scope.endpoint,
+              $scope.cube,
+              $scope.state,
+              wrapper,
+              $scope.colorScale()
+            );
 
             $scope.$emit('babbage-ui.create');
             $scope.$on('$destroy', function() {

--- a/src/bindings/angular/pie/index.js
+++ b/src/bindings/angular/pie/index.js
@@ -16,7 +16,8 @@ export class PieChartDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            colorScale: '&',
           },
           template: require('./template.html'),
           replace: false,
@@ -65,12 +66,14 @@ export class PieChartDirective {
 
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
+
             component.build(
               $scope.endpoint,
               $scope.cube,
               $scope.state,
               wrapper,
-              $scope.maxSlices
+              $scope.maxSlices,
+              $scope.colorScale()
             );
 
             $scope.$emit('babbage-ui.create');

--- a/src/bindings/angular/radar/index.js
+++ b/src/bindings/angular/radar/index.js
@@ -15,7 +15,8 @@ export class RadarChartDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            colorScale: '&',
           },
           template: require('./template.html'),
           replace: false,
@@ -59,8 +60,13 @@ export class RadarChartDirective {
 
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
-            component.build($scope.endpoint, $scope.cube,
-              $scope.state, wrapper);
+            component.build(
+              $scope.endpoint,
+              $scope.cube,
+              $scope.state,
+              wrapper,
+              $scope.colorScale()
+            );
 
             $scope.$emit('babbage-ui.create');
             $scope.$on('$destroy', function() {

--- a/src/bindings/angular/sankey/index.js
+++ b/src/bindings/angular/sankey/index.js
@@ -15,7 +15,8 @@ export class SanKeyChartDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            colorScale: '&',
           },
           template: require('./template.html'),
           replace: false,
@@ -64,7 +65,13 @@ export class SanKeyChartDirective {
 
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
-            component.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
+            component.build(
+              $scope.endpoint,
+              $scope.cube,
+              $scope.state,
+              wrapper,
+              $scope.colorScale()
+            );
 
             $scope.$emit('babbage-ui.create');
             $scope.$on('$destroy', function() {

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -10,13 +10,14 @@ class TreemapDirective {
         return {
           restrict: 'EA',
           scope: {
+            colorSchema: '@',
             endpoint: '@',
             cube: '@',
             state: '=',
             downloader: '=?',
             formatValue: '=?',
             messages: '=?',
-            colorSchema: '@',
+            colorScale: '&',
           },
           template: require('./template.html'),
           replace: false,
@@ -89,8 +90,13 @@ class TreemapDirective {
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
 
-            const colorSchema = $scope.$eval($scope.colorSchema);
-            component.build($scope.endpoint, $scope.cube, $scope.state, wrapper, colorSchema);
+            component.build(
+              $scope.endpoint,
+              $scope.cube,
+              $scope.state,
+              wrapper,
+              $scope.colorScale()
+            );
 
             $scope.$emit('babbage-ui.create');
             $scope.$on('$destroy', function() {

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -15,7 +15,8 @@ class TreemapDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            colorSchema: '@',
           },
           template: require('./template.html'),
           replace: false,
@@ -87,7 +88,9 @@ class TreemapDirective {
             });
             component.downloader = $scope.downloader;
             $scope.$emit('babbage-ui.initialize', component);
-            component.build($scope.endpoint, $scope.cube, $scope.state, wrapper);
+
+            const colorSchema = $scope.$eval($scope.colorSchema);
+            component.build($scope.endpoint, $scope.cube, $scope.state, wrapper, colorSchema);
 
             $scope.$emit('babbage-ui.create');
             $scope.$on('$destroy', function() {

--- a/src/bindings/vuejs/Pie.vue
+++ b/src/bindings/vuejs/Pie.vue
@@ -34,7 +34,8 @@
             'endpoint',
             'pieid',
             'simulation',
-            'maxSlices'
+            'maxSlices',
+            'colorScale'
         ],
         components: {},
         data () {
@@ -69,7 +70,8 @@
                     this.cube,
                     this.state,
                     wrapper,
-                    this.maxSlices
+                    this.maxSlices,
+                    this.colorScale
                 )
                 pieChart.on('click', function (PieChartComponent, item) {
                             // DEBUG:

--- a/src/bindings/vuejs/TreeMap.vue
+++ b/src/bindings/vuejs/TreeMap.vue
@@ -64,7 +64,7 @@
     import TreeMapComponent from '../../components/treemap'
 
     export default {
-        props: ['cube', 'endpoint', 'treemapid', 'simulation'],
+        props: ['cube', 'endpoint', 'treemapid', 'simulation', 'colorSchema'],
         components: {},
         data () {
             return {
@@ -128,7 +128,7 @@
                 const wrapper = document.querySelector("div#treemap-kpkt")
                 // Build and track events??
                 // Maybe assign it to a map; so can drill up and down; cached??
-                treeMap.build(endpoint, cube, state, wrapper)
+                treeMap.build(endpoint, cube, state, wrapper, this.colorSchema)
                 treeMap.on('click', function (treeMapComponent, item) {
                             this.$emit('treemap-click', treeMapComponent, item)
                             // console.error("TREE:", util.inspect(treeMapComponent.treemap(), {depth: 4}))

--- a/src/bindings/vuejs/TreeMap.vue
+++ b/src/bindings/vuejs/TreeMap.vue
@@ -64,7 +64,7 @@
     import TreeMapComponent from '../../components/treemap'
 
     export default {
-        props: ['cube', 'endpoint', 'treemapid', 'simulation', 'colorSchema'],
+        props: ['cube', 'endpoint', 'treemapid', 'simulation', 'colorScale'],
         components: {},
         data () {
             return {
@@ -128,7 +128,7 @@
                 const wrapper = document.querySelector("div#treemap-kpkt")
                 // Build and track events??
                 // Maybe assign it to a map; so can drill up and down; cached??
-                treeMap.build(endpoint, cube, state, wrapper, this.colorSchema)
+                treeMap.build(endpoint, cube, state, wrapper, this.colorScale)
                 treeMap.on('click', function (treeMapComponent, item) {
                             this.$emit('treemap-click', treeMapComponent, item)
                             // console.error("TREE:", util.inspect(treeMapComponent.treemap(), {depth: 4}))

--- a/src/components/bubbletree/index.js
+++ b/src/components/bubbletree/index.js
@@ -70,7 +70,7 @@ export class BubbleTreeComponent extends events.EventEmitter {
     return result.amount > 0 ? result : null;
   };
 
-  build(endpoint, cube, params, wrapper, colorSchema) {
+  build(endpoint, cube, params, wrapper) {
     var that = this;
     this.wrapper = wrapper;
 

--- a/src/components/chart/index.js
+++ b/src/components/chart/index.js
@@ -39,11 +39,15 @@ export class ChartComponent extends events.EventEmitter {
     };
   }
 
-  build(chartType, endpoint, cube, params, wrapper, colorSchema) {
+  build(chartType, endpoint, cube, params, wrapper, colorScale) {
     params = _.cloneDeep(params);
 
     var that = this;
     this.wrapper = wrapper;
+
+    if (colorScale === undefined) {
+      colorScale = Utils.defaultColorScale();
+    }
 
     that.emit('loading', that);
 
@@ -94,7 +98,7 @@ export class ChartComponent extends events.EventEmitter {
               if ((chartType == 'bar') && !series) {
                 c = d.index;
               }
-              return Utils.colorScale(c);
+              return colorScale(c);
             },
             type: chartType || 'bar',
             x: _.first(_.first(columns)),

--- a/src/components/pie/index.js
+++ b/src/components/pie/index.js
@@ -48,19 +48,22 @@ export class PieChartComponent extends events.EventEmitter {
     };
   }
 
-  build(endpoint, cube, params, wrapper, maxSlices=5, colorSchema) {
+  build(endpoint, cube, params, wrapper, maxSlices=5, colorScale) {
     params = _.cloneDeep(params);
 
     var that = this;
     this.wrapper = wrapper;
+
+    if (colorScale === undefined) {
+      colorScale = Utils.defaultColorScale();
+    }
 
     return this._getData(endpoint, cube, params, maxSlices)
       .then((data) => {
         var columns = Utils.buildC3PieColumns(data, params.aggregates);
         var colors = {};
         _.each(columns, (value, index) => {
-          // FIXME: colorSchema should be used here
-          colors[value[0]] = Utils.colorScale(index);
+          colors[value[0]] = colorScale(index);
         });
 
         var currency = data.currency[params.aggregates];

--- a/src/components/radar/index.js
+++ b/src/components/radar/index.js
@@ -18,7 +18,7 @@ function RadarChart(wrapper, allData, legendOptions, options) {
     opacityCircles: 0.1, 	//The opacity of the circles of each blob
     strokeWidth: 2, 		//The width of the stroke around each blob
     roundStrokes: false,	//If true the area and stroke will follow a round path (cardinal-closed)
-    color: d3.scale.category20(),	//Color function
+    color: Utils.defaultColorScale(),	//Color function
     formatValue: d3.format(',') //Percentage formatting
   };
   var data = _.map(allData, function(datum) {
@@ -461,9 +461,13 @@ export class RadarChartComponent extends events.EventEmitter {
       });
   }
 
-  build(endpoint, cube, params, wrapper) {
+  build(endpoint, cube, params, wrapper, colorScale) {
     var that = this;
     this.wrapper = wrapper;
+
+    if (colorScale === undefined) {
+      colorScale = Utils.defaultColorScale();
+    }
 
     that.emit('loading', that);
 
@@ -517,7 +521,6 @@ export class RadarChartComponent extends events.EventEmitter {
         var margin = {top: 100, right: 100, bottom: 100, left: 100},
           width = Math.min(700, window.innerWidth - 10) - margin.left - margin.right,
           height = Math.min(width, window.innerHeight - margin.top - margin.bottom - 20);
-        var color = d3.scale.category10();
 
         var radarChartOptions = {
           w: width,
@@ -526,7 +529,7 @@ export class RadarChartComponent extends events.EventEmitter {
           maxValue: 0.5,
           levels: 5,
           roundStrokes: true,
-          color: color,
+          color: colorScale,
           formatValue: valueFormat
         };
 

--- a/src/components/sankey/index.js
+++ b/src/components/sankey/index.js
@@ -42,9 +42,13 @@ export class SanKeyChartComponent extends events.EventEmitter {
     };
   }
 
-  build(endpoint, cube, params, wrapper, colorSchema) {
+  build(endpoint, cube, params, wrapper, colorScale) {
     var that = this;
     this.wrapper = wrapper;
+
+    if (colorScale === undefined) {
+      colorScale = Utils.defaultColorScale();
+    }
 
     var unit = 15;
     var margin = {top: unit / 2, right: 1, bottom: 6, left: 1};
@@ -125,7 +129,7 @@ export class SanKeyChartComponent extends events.EventEmitter {
             graph.nodes.push({
               key: source.keyValue,
               name: source.nameValue,
-              color: Utils.colorScale(sourceId),
+              color: colorScale(sourceId),
               isSource: true
             });
             objs[sourceId] = {idx: graph.nodes.length - 1};

--- a/src/components/treemap/index.js
+++ b/src/components/treemap/index.js
@@ -54,9 +54,13 @@ export class TreeMapComponent extends events.EventEmitter {
     return formatValue;
   }
 
-  build(endpoint, cube, params, wrapper, colorSchema) {
+  build(endpoint, cube, params, wrapper, colorScale) {
     params = _.cloneDeep(params);
     var that = this;
+
+    if (colorScale === undefined) {
+      colorScale = Utils.defaultColorScale();
+    }
 
     this.wrapper = wrapper;
     var size = {
@@ -106,7 +110,7 @@ export class TreeMapComponent extends events.EventEmitter {
           cell.value = measure.value;
           cell.key = dimension.keyValue;
           cell.name = dimension.nameValue;
-          cell.color = Utils.colorScale(index, colorSchema);
+          cell.color = colorScale(index);
 
           cell.percentage = (measure.value && data.summary && params.aggregates)
             ? (measure.value / Math.max(data.summary[params.aggregates], 1))

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,24 +1,9 @@
 import d3 from 'd3'
 import _ from 'lodash'
 
-var defaultColorSchema = [
-  '#CF3D1E', '#F15623', '#F68B1F', '#FFC60B', '#DFCE21',
-  '#BCD631', '#95C93D', '#48B85C', '#00833D', '#00B48D',
-  '#60C4B1', '#27C4F4', '#478DCB', '#3E67B1', '#4251A3', '#59449B',
-  '#6E3F7C', '#6A246D', '#8A4873', '#EB0080', '#EF58A0', '#C05A89'
-];
-
-var scale = d3.scale.ordinal();
-
 export var numberFormat = d3.format('0,000');
 
-export function colorScale(index, colorSchema) {
-  const colors = (_.isArray(colorSchema)) ? colorSchema : defaultColorSchema;
-
-  scale.range(colors);
-
-  return scale(index);
-}
+export const defaultColorScale = d3.scale.category10;
 
 export function buildC3Names(data) {
   var result = {};

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -100,20 +100,6 @@ export function buildC3BarColumns(data, aggregates) {
 }
 
 
-export function buildC3Colors(data, colorSchema) {
-  return _.map(data.cells, (item, index) => {
-    var dimension = _.first(item.dimensions);
-    return [dimension.keyValue, colorScale(index, colorSchema)];
-  });
-}
-
-export function buildC3BarColors(data, colorSchema) {
-  return _.map(data.cells, (item, index) => {
-    var dimension = _.first(item.dimensions);
-    return [dimension.keyValue, colorScale(index, colorSchema)];
-  });
-}
-
 export function moneyFormat(amount, currency) {
   if (amount && currency) {
     let currencySymbol = {USD: '$', GBP:'£', EUR: '€', JPY: '¥'}[currency];

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -13,9 +13,9 @@ var scale = d3.scale.ordinal();
 export var numberFormat = d3.format('0,000');
 
 export function colorScale(index, colorSchema) {
-  scale.range(
-    _.isArray(colorSchema) || defaultColorSchema
-  );
+  const colors = (_.isArray(colorSchema)) ? colorSchema : defaultColorSchema;
+
+  scale.range(colors);
 
   return scale(index);
 }

--- a/test/component-utils.js
+++ b/test/component-utils.js
@@ -2,7 +2,7 @@ var assert = require('chai').assert;
 var _ = require('lodash');
 
 describe('Babbage.ui component utils', function() {
-  var Utils = require('../lib/components/utils.js');
+  var Utils = require('../src/components/utils.js');
   var data = require('./data/component-utils/data1');
 
   it('Should exists', function(done) {
@@ -36,6 +36,18 @@ describe('Babbage.ui component utils', function() {
     done();
   });
 
+  describe('colorScale', () => {
+    it('Should use the default color schema when one isn\'t passed', () => {
+      assert.isDefined(Utils.colorScale(0));
+    });
 
+    it('Should use the passed color schema', () => {
+      const colorSchema = ['#FFF', '#333', '#000'];
+
+      colorSchema.forEach((color, index) => {
+        assert.equal(Utils.colorScale(index, colorSchema), color);
+      });
+    });
+  });
 });
 

--- a/test/component-utils.js
+++ b/test/component-utils.js
@@ -26,27 +26,10 @@ describe('Babbage.ui component utils', function() {
     done();
   });
 
-  it('Should build `colors`', function(done) {
-    var result = Utils.buildC3Colors(data);
-    assert.deepEqual(result, [
-      [10, '#CF3D1E'],
-      [20, '#F15623'],
-      [30, '#F68B1F']
-    ]);
-    done();
-  });
-
-  describe('colorScale', () => {
-    it('Should use the default color schema when one isn\'t passed', () => {
-      assert.isDefined(Utils.colorScale(0));
-    });
-
-    it('Should use the passed color schema', () => {
-      const colorSchema = ['#FFF', '#333', '#000'];
-
-      colorSchema.forEach((color, index) => {
-        assert.equal(Utils.colorScale(index, colorSchema), color);
-      });
+  describe('defaultColorScale', () => {
+    it('Should return a color scale', () => {
+      assert.isFunction(Utils.defaultColorScale());
+      assert.isString(Utils.defaultColorScale()(0));
     });
   });
 });


### PR DESCRIPTION
See https://github.com/openspending/os-viewer/pull/159 for more information on what this allows. Also, make sure whoever merges this squashes the commits into a single one, as they're noisy.

We also need to bump babbage-ui's version number (following semver, to `1.5.0`), and use the new version on os-viewer

Fixes openspending/openspending#1235