### PR TITLE
Fix bug with JQuery usage in PivotTable's Angular binding

### DIFF
--- a/src/bindings/angular/pivottable/index.js
+++ b/src/bindings/angular/pivottable/index.js
@@ -4,6 +4,7 @@ import {createI18NMapper} from '../utils'
 
 // Include `pivottable` jquery plugin into bundle. Do not remove this line!
 import 'pivottable'
+const jQuery = require('jquery');
 
 export class PivotTableDirective {
   init(angularModule) {
@@ -59,11 +60,11 @@ export class PivotTableDirective {
               $scope.$emit('babbage-ui.ready', component, data, error);
             });
 
-            let sum = $.pivotUtilities.aggregatorTemplates.sum;
+            let sum = jQuery.pivotUtilities.aggregatorTemplates.sum;
 
             let formatValue = $scope.formatValue;
             if (!_.isFunction(formatValue)) {
-              let numberFormat = $.pivotUtilities.numberFormat;
+              let numberFormat = jQuery.pivotUtilities.numberFormat;
               formatValue = numberFormat({digitsAfterDecimal: 0});
             }
 
@@ -79,7 +80,7 @@ export class PivotTableDirective {
                 ) {
                   $scope.status.isTooMuchData = true;
                 } else {
-                  $(wrapper).pivot(
+                  jQuery(wrapper).pivot(
                     result.data,
                     {
                       rows: result.rows,


### PR DESCRIPTION
Taking the example of using `babbage.ui` inside `os-viewer`, this is what
happens:

On `os-viewer`, we run `window.$ = window.jQuery = require('jquery')` to add
jQuery to the global scope.

On `babbage.ui`'s PivotTable, we run `import 'pivottable'`, which internally
runs `require('jquery')` and adds itself to the returned instance.

To allow multiple versions of the same dependency to coexist, Webpack returns
a different instance when you require jquery on `os-viewer` and on `babbage.ui`
(on `os-viewer` we use jQuery v2.1.4, while on `babbage.ui` we use v1.12.4
because of `bubbletree`). This means that if you require jQuery inside
`babbage.ui`, it'll return v1.12.4, while if you do the same inside
`os-viewer`, it'll return v2.1.4.

As we're running `import 'pivottable'` inside `babbage.ui`, the pivottable will
be added to jQuery v1.12.4. However, in the PivotTable's Angular binding, we're
using the global $ instance, which is set to `os-viewer`'s version.

All of this means that we use the wrong jQuery version inside the Angular
binding, which raises an exception because `pivottable` wasn't loaded in this
version. This commit fixes this by explictly requiring jQuery, instead of using
the global `$`. Webpack will make sure we're using the correct version.