### PR TITLE
[WIP] [#1264] Use d3 Sankey library from npm to avoid napa

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,13708 @@
+{
+  "name": "babbage.ui",
+  "version": "1.5.0",
+  "dependencies": {
+    "babel-cli": {
+      "version": "6.24.1",
+      "from": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
+      "dependencies": {
+        "babel-register": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "home-or-tmp": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "source-map-support": {
+              "version": "0.4.15",
+              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+        },
+        "fs-readdir-recursive": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz"
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "arrify": {
+                  "version": "1.0.1",
+                  "from": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.5",
+                      "from": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.2",
+                          "from": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "from": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "from": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                },
+                                "isobject": {
+                                  "version": "2.1.0",
+                                  "from": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.7",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "3.0.0",
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "kind-of": {
+                                      "version": "4.0.0",
+                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.5",
+                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.5",
+                      "from": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "from": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                          "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "from": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                      "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.5",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                      "dependencies": {
+                        "remove-trailing-separator": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "object.omit": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.5",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "from": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "from": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "from": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                          "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.3",
+                      "from": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.8.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "from": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                }
+              }
+            },
+            "readdirp": {
+              "version": "2.1.0",
+              "from": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.11",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "from": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.25.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "js-tokens": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.25.0",
+          "from": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+          "dependencies": {
+            "detect-indent": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+              "dependencies": {
+                "repeating": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            }
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+        },
+        "babel-template": {
+          "version": "6.25.0",
+          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        },
+        "babel-register": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "home-or-tmp": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "source-map-support": {
+              "version": "0.4.15",
+              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "6.25.0",
+          "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+          "dependencies": {
+            "globals": {
+              "version": "9.18.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                  "dependencies": {
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.25.0",
+          "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "2.0.2",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.17.3",
+          "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+        },
+        "debug": {
+          "version": "2.6.8",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            }
+          }
+        },
+        "json5": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.8",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "private": {
+          "version": "0.1.7",
+          "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "babel-loader": {
+      "version": "6.4.1",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "dependencies": {
+            "commondir": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "from": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "from": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                      "resolved": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "from": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "2.4.1",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-optimise-call-expression": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+            },
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                }
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                }
+              }
+            },
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                },
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.17.3",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.3",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.24.1",
+                  "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babylon": {
+                      "version": "6.17.3",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.3",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.24.1",
+                  "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.3",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.24.1",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+          "dependencies": {
+            "regenerator-transform": {
+              "version": "0.9.11",
+              "from": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+              "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+              "dependencies": {
+                "babel-runtime": {
+                  "version": "6.23.0",
+                  "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.5",
+                      "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+    },
+    "bootstrap": {
+      "version": "3.3.4",
+      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
+    },
+    "bubbletree": {
+      "version": "2.0.4",
+      "from": "git+https://github.com/okfn/bubbletree.git#d797bff3ef22d22951acf6f55a83f6555d7a801a",
+      "resolved": "git+https://github.com/okfn/bubbletree.git#d797bff3ef22d22951acf6f55a83f6555d7a801a",
+      "dependencies": {
+        "jquery": {
+          "version": "1.12.4",
+          "from": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz"
+        },
+        "webpack-raphael": {
+          "version": "2.1.4",
+          "from": "https://registry.npmjs.org/webpack-raphael/-/webpack-raphael-2.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/webpack-raphael/-/webpack-raphael-2.1.4.tgz",
+          "dependencies": {
+            "eve": {
+              "version": "0.4.1",
+              "from": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+              "resolved": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+            }
+          }
+        },
+        "tween.js": {
+          "version": "16.6.0",
+          "from": "https://registry.npmjs.org/tween.js/-/tween.js-16.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.6.0.tgz"
+        }
+      }
+    },
+    "c3": {
+      "version": "0.4.13",
+      "from": "git+https://github.com/masayuki0812/c3.git#c3553a6c9e18f652a5226a4f83f2ef7f6e88293d",
+      "resolved": "git+https://github.com/masayuki0812/c3.git#c3553a6c9e18f652a5226a4f83f2ef7f6e88293d"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "from": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.0.2",
+          "from": "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "from": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "from": "http://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+        }
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.0.4",
+      "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "css-loader": {
+      "version": "0.25.0",
+      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "js-tokens": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            }
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+          "dependencies": {
+            "cssesc": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+            },
+            "fastparse": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cssnano": {
+          "version": "3.10.0",
+          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+          "dependencies": {
+            "autoprefixer": {
+              "version": "6.7.7",
+              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+              "dependencies": {
+                "browserslist": {
+                  "version": "1.7.7",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                  "dependencies": {
+                    "electron-to-chromium": {
+                      "version": "1.3.14",
+                      "from": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
+                      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz"
+                    }
+                  }
+                },
+                "caniuse-db": {
+                  "version": "1.0.30000683",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz",
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz"
+                },
+                "normalize-range": {
+                  "version": "0.1.2",
+                  "from": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "from": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+            },
+            "defined": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
+            "has": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
+              "dependencies": {
+                "function-bind": {
+                  "version": "1.1.0",
+                  "from": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                }
+              }
+            },
+            "postcss-calc": {
+              "version": "5.3.1",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+              "dependencies": {
+                "postcss-message-helpers": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                },
+                "reduce-css-calc": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "math-expression-evaluator": {
+                      "version": "1.2.17",
+                      "from": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+                      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz"
+                    },
+                    "reduce-function-call": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-colormin": {
+              "version": "2.2.2",
+              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+              "dependencies": {
+                "colormin": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+                  "dependencies": {
+                    "color": {
+                      "version": "0.11.4",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+                      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+                      "dependencies": {
+                        "clone": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                        },
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.2",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "color-string": {
+                          "version": "0.3.0",
+                          "from": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                          "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.2",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "css-color-names": {
+                      "version": "0.0.4",
+                      "from": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-convert-values": {
+              "version": "2.6.1",
+              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz"
+            },
+            "postcss-discard-comments": {
+              "version": "2.0.4",
+              "from": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
+            },
+            "postcss-discard-duplicates": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz"
+            },
+            "postcss-discard-empty": {
+              "version": "2.1.0",
+              "from": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
+            },
+            "postcss-discard-overridden": {
+              "version": "0.1.1",
+              "from": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz"
+            },
+            "postcss-discard-unused": {
+              "version": "2.2.3",
+              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+              "dependencies": {
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-filter-plugins": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+              "dependencies": {
+                "uniqid": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+                  "dependencies": {
+                    "macaddress": {
+                      "version": "0.2.8",
+                      "from": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-merge-idents": {
+              "version": "2.1.7",
+              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz"
+            },
+            "postcss-merge-longhand": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz"
+            },
+            "postcss-merge-rules": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+              "dependencies": {
+                "browserslist": {
+                  "version": "1.7.7",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                  "dependencies": {
+                    "caniuse-db": {
+                      "version": "1.0.30000683",
+                      "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz",
+                      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz"
+                    },
+                    "electron-to-chromium": {
+                      "version": "1.3.14",
+                      "from": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
+                      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz"
+                    }
+                  }
+                },
+                "caniuse-api": {
+                  "version": "1.6.1",
+                  "from": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+                  "dependencies": {
+                    "caniuse-db": {
+                      "version": "1.0.30000683",
+                      "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz",
+                      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz"
+                    },
+                    "lodash.memoize": {
+                      "version": "4.1.2",
+                      "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+                    },
+                    "lodash.uniq": {
+                      "version": "4.5.0",
+                      "from": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+                    }
+                  }
+                },
+                "postcss-selector-parser": {
+                  "version": "2.2.3",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "dependencies": {
+                    "flatten": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+                    },
+                    "indexes-of": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+                    },
+                    "uniq": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                    }
+                  }
+                },
+                "vendors": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+                }
+              }
+            },
+            "postcss-minify-font-values": {
+              "version": "1.0.5",
+              "from": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz"
+            },
+            "postcss-minify-gradients": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz"
+            },
+            "postcss-minify-params": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-minify-selectors": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "postcss-selector-parser": {
+                  "version": "2.2.3",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "dependencies": {
+                    "flatten": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+                    },
+                    "indexes-of": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+                    },
+                    "uniq": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-normalize-charset": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz"
+            },
+            "postcss-normalize-url": {
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+              "dependencies": {
+                "is-absolute-url": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
+                },
+                "normalize-url": {
+                  "version": "1.9.1",
+                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                  "dependencies": {
+                    "prepend-http": {
+                      "version": "1.0.4",
+                      "from": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+                    },
+                    "query-string": {
+                      "version": "4.3.4",
+                      "from": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+                      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+                      "dependencies": {
+                        "strict-uri-encode": {
+                          "version": "1.1.0",
+                          "from": "http://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+                          "resolved": "http://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "sort-keys": {
+                      "version": "1.1.2",
+                      "from": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+                      "resolved": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+                      "dependencies": {
+                        "is-plain-obj": {
+                          "version": "1.1.0",
+                          "from": "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-ordered-values": {
+              "version": "2.2.3",
+              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz"
+            },
+            "postcss-reduce-idents": {
+              "version": "2.4.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz"
+            },
+            "postcss-reduce-initial": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz"
+            },
+            "postcss-reduce-transforms": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz"
+            },
+            "postcss-svgo": {
+              "version": "2.1.6",
+              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+              "dependencies": {
+                "is-svg": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+                  "dependencies": {
+                    "html-comment-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "svgo": {
+                  "version": "0.7.2",
+                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
+                    },
+                    "coa": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
+                      "dependencies": {
+                        "q": {
+                          "version": "1.5.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+                        }
+                      }
+                    },
+                    "js-yaml": {
+                      "version": "3.7.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.9",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                          "dependencies": {
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "from": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                              "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.7.3",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+                        }
+                      }
+                    },
+                    "colors": {
+                      "version": "1.1.2",
+                      "from": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "from": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+                      "resolved": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "csso": {
+                      "version": "2.3.2",
+                      "from": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+                      "dependencies": {
+                        "clap": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/clap/-/clap-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.3.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "source-map": {
+                          "version": "0.5.6",
+                          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-unique-selectors": {
+              "version": "2.0.2",
+              "from": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-value-parser": {
+              "version": "3.3.0",
+              "from": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+            },
+            "postcss-zindex": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+              "dependencies": {
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "lodash.camelcase": {
+          "version": "3.0.1",
+          "from": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+          "dependencies": {
+            "lodash._createcompounder": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+              "dependencies": {
+                "lodash.deburr": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash.words": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.2",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.7.0",
+              "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "dependencies": {
+                "cssesc": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+                },
+                "fastparse": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+                },
+                "regexpu-core": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "dependencies": {
+                    "regenerate": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss": {
+              "version": "6.0.2",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.7.0",
+              "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "dependencies": {
+                "cssesc": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+                },
+                "fastparse": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+                },
+                "regexpu-core": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "dependencies": {
+                    "regenerate": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss": {
+              "version": "6.0.2",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+          "dependencies": {
+            "icss-replace-symbols": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz"
+            },
+            "postcss": {
+              "version": "6.0.2",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "source-list-map": {
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+        }
+      }
+    },
+    "d3": {
+      "version": "3.5.17",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+    },
+    "d3-plugins-sankey-fixed": {
+      "version": "1.3.0",
+      "from": "https://registry.npmjs.org/d3-plugins-sankey-fixed/-/d3-plugins-sankey-fixed-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-plugins-sankey-fixed/-/d3-plugins-sankey-fixed-1.3.0.tgz"
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "from": "http://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "from": "http://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+        },
+        "interpret": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
+        },
+        "liftoff": {
+          "version": "2.3.0",
+          "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+          "dependencies": {
+            "extend": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "findup-sync": {
+              "version": "0.4.3",
+              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+              "dependencies": {
+                "detect-file": {
+                  "version": "0.1.0",
+                  "from": "http://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+                  "dependencies": {
+                    "fs-exists-sync": {
+                      "version": "0.1.0",
+                      "from": "http://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+                      "resolved": "http://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.5",
+                      "from": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.2",
+                          "from": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "from": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "from": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                },
+                                "isobject": {
+                                  "version": "2.1.0",
+                                  "from": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.7",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "3.0.0",
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "kind-of": {
+                                      "version": "4.0.0",
+                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.5",
+                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.5",
+                      "from": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "from": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                          "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "from": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                      "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.5",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                      "dependencies": {
+                        "remove-trailing-separator": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "object.omit": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.5",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "from": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "from": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "from": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                          "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                          "dependencies": {
+                            "glob-parent": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.3",
+                      "from": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve-dir": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+                  "dependencies": {
+                    "expand-tilde": {
+                      "version": "1.2.2",
+                      "from": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                      "resolved": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "global-modules": {
+                      "version": "0.2.3",
+                      "from": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+                      "dependencies": {
+                        "global-prefix": {
+                          "version": "0.1.5",
+                          "from": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+                          "dependencies": {
+                            "homedir-polyfill": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                              "dependencies": {
+                                "parse-passwd": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "ini": {
+                              "version": "1.3.4",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                            },
+                            "which": {
+                              "version": "1.2.14",
+                              "from": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+                              "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+                              "dependencies": {
+                                "isexe": {
+                                  "version": "2.0.0",
+                                  "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "0.2.0",
+                          "from": "http://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "fined": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+              "dependencies": {
+                "expand-tilde": {
+                  "version": "1.2.2",
+                  "from": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                  "resolved": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                    }
+                  }
+                },
+                "lodash.assignwith": {
+                  "version": "4.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz"
+                },
+                "lodash.isempty": {
+                  "version": "4.4.0",
+                  "from": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz"
+                },
+                "lodash.pick": {
+                  "version": "4.4.0",
+                  "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
+                },
+                "parse-filepath": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.2.6",
+                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+                          "dependencies": {
+                            "is-unc-path": {
+                              "version": "0.1.2",
+                              "from": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+                              "dependencies": {
+                                "unc-path-regex": {
+                                  "version": "0.1.2",
+                                  "from": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "0.2.0",
+                          "from": "http://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "map-cache": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+                    },
+                    "path-root": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+                      "dependencies": {
+                        "path-root-regex": {
+                          "version": "0.1.2",
+                          "from": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "0.3.2",
+              "from": "http://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+              "resolved": "http://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
+            },
+            "lodash.isstring": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
+            },
+            "lodash.mapvalues": {
+              "version": "4.6.0",
+              "from": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "from": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+            },
+            "resolve": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+              "dependencies": {
+                "path-parse": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "orchestrator": {
+          "version": "0.3.8",
+          "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "from": "http://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "resolved": "http://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "http://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "resolved": "http://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "from": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        },
+        "tildify": {
+          "version": "1.2.0",
+          "from": "http://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.14",
+          "from": "http://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.3",
+              "from": "http://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "http://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "resolved": "http://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "http://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "http://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "resolved": "http://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "http://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "resolved": "http://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "http://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "resolved": "http://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.2",
+                  "from": "http://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                  "resolved": "http://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "http://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "resolved": "http://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "http://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "resolved": "http://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.2",
+                              "from": "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                              "resolved": "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.11",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "dependencies": {
+                "natives": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "from": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "http://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "resolved": "http://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "http://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-autoprefixer": {
+      "version": "3.1.1",
+      "from": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
+      "dependencies": {
+        "autoprefixer": {
+          "version": "6.7.7",
+          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "dependencies": {
+            "browserslist": {
+              "version": "1.7.7",
+              "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+              "dependencies": {
+                "electron-to-chromium": {
+                  "version": "1.3.14",
+                  "from": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
+                  "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz"
+                }
+              }
+            },
+            "caniuse-db": {
+              "version": "1.0.30000683",
+              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000683.tgz"
+            },
+            "normalize-range": {
+              "version": "0.1.2",
+              "from": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+              "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "from": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+            },
+            "postcss-value-parser": {
+              "version": "3.3.0",
+              "from": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+            }
+          }
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.1",
+          "from": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-babel": {
+      "version": "6.1.2",
+      "from": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.1",
+          "from": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-clean-css": {
+      "version": "2.4.0",
+      "from": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-2.4.0.tgz",
+      "dependencies": {
+        "clean-css": {
+          "version": "4.1.3",
+          "from": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.3.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.1",
+          "from": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.6.1",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "dependencies": {
+        "vinyl": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "clone-buffer": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz"
+            },
+            "clone-stats": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz"
+            },
+            "cloneable-readable": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                }
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "from": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+            },
+            "remove-trailing-separator": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-include-file": {
+      "version": "0.1.1",
+      "from": "git+https://github.com/tweedegolf/gulp-include-file.git#2fc4274029f3f34911a7574b09cbf5a8fabbd544",
+      "resolved": "git+https://github.com/tweedegolf/gulp-include-file.git#2fc4274029f3f34911a7574b09cbf5a8fabbd544"
+    },
+    "gulp-less": {
+      "version": "3.3.0",
+      "from": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.3.0.tgz",
+      "dependencies": {
+        "accord": {
+          "version": "0.26.4",
+          "from": "https://registry.npmjs.org/accord/-/accord-0.26.4.tgz",
+          "resolved": "https://registry.npmjs.org/accord/-/accord-0.26.4.tgz",
+          "dependencies": {
+            "convert-source-map": {
+              "version": "1.5.0",
+              "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+            },
+            "glob": {
+              "version": "7.1.2",
+              "from": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                }
+              }
+            },
+            "indx": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
+            },
+            "lodash.clone": {
+              "version": "4.5.0",
+              "from": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz"
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "from": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
+            },
+            "lodash.merge": {
+              "version": "4.6.0",
+              "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz"
+            },
+            "lodash.partialright": {
+              "version": "4.2.1",
+              "from": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz"
+            },
+            "lodash.pick": {
+              "version": "4.4.0",
+              "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
+            },
+            "lodash.uniq": {
+              "version": "4.5.0",
+              "from": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+            },
+            "resolve": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+              "dependencies": {
+                "path-parse": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            },
+            "uglify-js": {
+              "version": "2.8.28",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "from": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            },
+            "when": {
+              "version": "3.7.8",
+              "from": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
+            }
+          }
+        },
+        "less": {
+          "version": "2.7.2",
+          "from": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "image-size": {
+              "version": "0.5.5",
+              "from": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+              "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz"
+            },
+            "mime": {
+              "version": "1.3.6",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.1.1",
+              "from": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "request": {
+              "version": "2.81.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "from": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "dependencies": {
+                    "ajv": {
+                      "version": "4.11.8",
+                      "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                      "dependencies": {
+                        "co": {
+                          "version": "4.6.0",
+                          "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                        },
+                        "json-stable-stringify": {
+                          "version": "1.0.1",
+                          "from": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "dependencies": {
+                            "jsonify": {
+                              "version": "0.0.0",
+                              "from": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "har-schema": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "from": "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.4.0",
+                      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        },
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.13.1",
+                      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "from": "http://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                        },
+                        "getpass": {
+                          "version": "0.1.7",
+                          "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+                        },
+                        "jsbn": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.5",
+                          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "http://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "resolved": "http://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "from": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.1.0",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.1",
+          "from": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "1.12.0",
+      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.0.tgz",
+      "dependencies": {
+        "@gulp-sourcemaps/map-sources": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "dependencies": {
+                "remove-trailing-separator": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "acorn": {
+          "version": "4.0.13",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+        },
+        "css": {
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@0.1.43",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            },
+            "source-map-resolve": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+              "dependencies": {
+                "source-map-url": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                },
+                "atob": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
+                },
+                "resolve-url": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
+          }
+        },
+        "debug-fabulous": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "lazy-debug-legacy": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "from": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            }
+          }
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "from": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            }
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "dependencies": {
+        "array-differ": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "from": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+        },
+        "beeper": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz"
+        },
+        "fancy-log": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+          "dependencies": {
+            "time-stamp": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+            }
+          }
+        },
+        "gulplog": {
+          "version": "1.0.0",
+          "from": "http://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "dependencies": {
+            "glogg": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "has-gulplog": {
+          "version": "0.1.0",
+          "from": "http://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "dependencies": {
+            "sparkles": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+            }
+          }
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "from": "http://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "from": "http://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "from": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+        },
+        "lodash.template": {
+          "version": "3.6.2",
+          "from": "http://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "http://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            },
+            "lodash.escape": {
+              "version": "3.2.0",
+              "from": "http://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+              "dependencies": {
+                "lodash._root": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "resolved": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "http://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "resolved": "http://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.1",
+              "from": "http://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "from": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "http://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "from": "http://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "from": "http://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "html-minifier": {
+      "version": "0.7.2",
+      "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
+      "dependencies": {
+        "change-case": {
+          "version": "2.3.1",
+          "from": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+          "dependencies": {
+            "camel-case": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+            },
+            "constant-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+            },
+            "dot-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+            },
+            "is-lower-case": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+            },
+            "is-upper-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+            },
+            "lower-case": {
+              "version": "1.1.4",
+              "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+            },
+            "lower-case-first": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+            },
+            "param-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+            },
+            "pascal-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+            },
+            "path-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+            },
+            "sentence-case": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+            },
+            "snake-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+            },
+            "swap-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+            },
+            "title-case": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+            },
+            "upper-case": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+            },
+            "upper-case-first": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+            }
+          }
+        },
+        "clean-css": {
+          "version": "3.1.9",
+          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.6.0",
+              "from": "commander@2.6.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@0.1.43",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "cli": {
+          "version": "0.6.6",
+          "from": "cli@0.6.6",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@0.1.2"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.4.10",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "http://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "resolved": "http://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.24",
+          "from": "uglify-js@2.4.24",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@3.5.4",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
+        }
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "from": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.1",
+          "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+          "dependencies": {
+            "encoding": {
+              "version": "0.1.12",
+              "from": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.17",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz"
+                }
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "from": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+            }
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+        }
+      }
+    },
+    "jscs": {
+      "version": "2.11.0",
+      "from": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
+      "dependencies": {
+        "babel-jscs": {
+          "version": "2.0.5",
+          "from": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.38",
+              "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.38",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+                },
+                "bluebird": {
+                  "version": "2.11.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+                },
+                "convert-source-map": {
+                  "version": "1.5.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "globals@6.4.1"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                      "resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "from": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                },
+                "private": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.8",
+                      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+                      "dependencies": {
+                        "detective": {
+                          "version": "4.5.0",
+                          "from": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "4.0.13",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "from": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.17",
+                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.5.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+                        },
+                        "recast": {
+                          "version": "0.11.23",
+                          "from": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.9.6",
+                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz"
+                            },
+                            "esprima": {
+                              "version": "3.1.3",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "from": "alter@0.2.0",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.6",
+                              "from": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "from": "ast-traverse@0.1.1"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "from": "breakable@1.0.0"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "from": "simple-fmt@0.1.0"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "from": "simple-is@0.2.0"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "from": "stringmap@0.2.2"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "from": "stringset@0.2.1"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "from": "tryor@0.1.2"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "from": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.6.1",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.4",
+                                      "from": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                                      "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.6.1",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "from": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "from": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "from": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "resolved": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "from": "http://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                              "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "from": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                              "resolved": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "recast": {
+                      "version": "0.10.43",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "ast-types": {
+                          "version": "0.8.15",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "http://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "lodash.assign": {
+              "version": "3.2.0",
+              "from": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "http://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "http://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "http://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "http://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.23",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                },
+                "es6-set": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.23",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.1.0",
+              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@0.1.2"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@2.3.0"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@1.5.1",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@0.1.0",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@1.1.3"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@1.1.1",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@1.3.0"
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@1.0.0"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.6",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "inherit": {
+              "version": "2.2.6",
+              "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz"
+            }
+          }
+        },
+        "jscs-jsdoc": {
+          "version": "1.3.2",
+          "from": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz",
+          "dependencies": {
+            "comment-parser": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.2.11",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "jsdoctypeparser": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz"
+            }
+          }
+        },
+        "jscs-preset-wikimedia": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz"
+        },
+        "jsonlint": {
+          "version": "1.6.2",
+          "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz",
+          "dependencies": {
+            "nomnom": {
+              "version": "1.8.1",
+              "from": "nomnom@1.8.1",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                },
+                "chalk": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "JSV": {
+              "version": "4.0.2",
+              "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.8",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "natural-compare": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz"
+        },
+        "pathval": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
+        },
+        "prompt": {
+          "version": "0.2.14",
+          "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
+            },
+            "read": {
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
+                }
+              }
+            },
+            "revalidator": {
+              "version": "0.1.8",
+              "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@0.2.1",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+                },
+                "i": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@0.4.2"
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.1.2",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "from": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                        },
+                        "inflight": {
+                          "version": "1.0.6",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "winston": {
+              "version": "0.8.3",
+              "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "colors": {
+                  "version": "0.6.2",
+                  "from": "colors@0.6.2",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+                },
+                "cycle": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+                },
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "pkginfo": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+                },
+                "stack-trace": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "reserved-words": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz"
+        },
+        "resolve": {
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+          "dependencies": {
+            "path-parse": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "to-double-quotes": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz"
+        },
+        "to-single-quotes": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz"
+        },
+        "vow": {
+          "version": "0.4.16",
+          "from": "https://registry.npmjs.org/vow/-/vow-0.4.16.tgz",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.16.tgz"
+        },
+        "vow-fs": {
+          "version": "0.3.6",
+          "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.6.tgz",
+          "dependencies": {
+            "uuid": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+            },
+            "vow-queue": {
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
+            },
+            "glob": {
+              "version": "7.1.2",
+              "from": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "3.1.0",
+          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz"
+        }
+      }
+    },
+    "jsdom": {
+      "version": "9.12.0",
+      "from": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "dependencies": {
+        "abab": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
+        },
+        "acorn": {
+          "version": "4.0.13",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz"
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+        },
+        "content-type-parser": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz"
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "from": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                },
+                "levn": {
+                  "version": "0.3.0",
+                  "from": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                  "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "2.0.6",
+                  "from": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                  "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz"
+        },
+        "nwmatcher": {
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.0.tgz"
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "from": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "dependencies": {
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.1",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "http://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "http://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "resolved": "http://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.27.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.0",
+              "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "from": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+            }
+          }
+        },
+        "sax": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "from": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "from": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            }
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz"
+        },
+        "whatwg-encoding": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.13",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+            }
+          }
+        },
+        "whatwg-url": {
+          "version": "4.8.0",
+          "from": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+          "dependencies": {
+            "tr46": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
+            },
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+        }
+      }
+    },
+    "jsdom-global": {
+      "version": "2.1.1",
+      "from": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-2.1.1.tgz"
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "mocha": {
+      "version": "3.4.2",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "from": "http://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "glob": {
+          "version": "7.1.1",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "from": "http://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+        },
+        "json3": {
+          "version": "3.3.2",
+          "from": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "from": "http://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "http://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._basecreate": {
+              "version": "3.0.3",
+              "from": "http://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "resolved": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "mocha-jsdom": {
+      "version": "1.1.0",
+      "from": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz"
+    },
+    "nock": {
+      "version": "7.7.3",
+      "from": "https://registry.npmjs.org/nock/-/nock-7.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-7.7.3.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "propagate": {
+          "version": "0.3.1",
+          "from": "http://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+        }
+      }
+    },
+    "parse5": {
+      "version": "2.2.3",
+      "from": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz"
+    },
+    "pivottable": {
+      "version": "2.13.0",
+      "from": "git+https://github.com/nicolaskruchten/pivottable.git#081f0c73533832838d13fc64d705920b5335f22f",
+      "resolved": "git+https://github.com/nicolaskruchten/pivottable.git#081f0c73533832838d13fc64d705920b5335f22f",
+      "dependencies": {
+        "jquery": {
+          "version": "3.2.1",
+          "from": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz"
+        }
+      }
+    },
+    "raphael": {
+      "version": "2.2.7",
+      "from": "https://registry.npmjs.org/raphael/-/raphael-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.7.tgz",
+      "dependencies": {
+        "eve-raphael": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz"
+        }
+      }
+    },
+    "raw-loader": {
+      "version": "0.5.1",
+      "from": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz"
+    },
+    "through2": {
+      "version": "2.0.3",
+      "from": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.2.11",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        }
+      }
+    },
+    "vue-html-loader": {
+      "version": "1.2.4",
+      "from": "https://registry.npmjs.org/vue-html-loader/-/vue-html-loader-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/vue-html-loader/-/vue-html-loader-1.2.4.tgz",
+      "dependencies": {
+        "es6-templates": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.11.23",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+              "dependencies": {
+                "ast-types": {
+                  "version": "0.9.6",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz"
+                },
+                "esprima": {
+                  "version": "3.1.3",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+                },
+                "private": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "fastparse": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+        },
+        "html-minifier": {
+          "version": "2.1.7",
+          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-2.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-2.1.7.tgz",
+          "dependencies": {
+            "change-case": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/change-case/-/change-case-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.1.tgz",
+              "dependencies": {
+                "camel-case": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz"
+                },
+                "constant-case": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz"
+                },
+                "dot-case": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz"
+                },
+                "header-case": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz"
+                },
+                "is-lower-case": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                },
+                "is-upper-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                },
+                "lower-case": {
+                  "version": "1.1.4",
+                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+                },
+                "lower-case-first": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+                },
+                "no-case": {
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz"
+                },
+                "param-case": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz"
+                },
+                "pascal-case": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz"
+                },
+                "path-case": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz"
+                },
+                "sentence-case": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz"
+                },
+                "snake-case": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz"
+                },
+                "swap-case": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                },
+                "title-case": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz"
+                },
+                "upper-case": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                },
+                "upper-case-first": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                }
+              }
+            },
+            "clean-css": {
+              "version": "3.4.27",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "he": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
+            },
+            "ncname": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+              "dependencies": {
+                "xml-char-classes": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
+                }
+              }
+            },
+            "relateurl": {
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
+            },
+            "uglify-js": {
+              "version": "2.6.4",
+              "from": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+              "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "from": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "vue-loader": {
+      "version": "9.9.5",
+      "from": "https://registry.npmjs.org/vue-loader/-/vue-loader-9.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-9.9.5.tgz",
+      "dependencies": {
+        "consolidate": {
+          "version": "0.14.5",
+          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
+          "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz"
+        },
+        "hash-sum": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz"
+        },
+        "js-beautify": {
+          "version": "1.6.14",
+          "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.11",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                }
+              }
+            },
+            "editorconfig": {
+              "version": "0.13.2",
+              "from": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+              "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "lru-cache": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                    }
+                  }
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "from": "http://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "resolved": "http://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "2.2.3",
+          "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+          "dependencies": {
+            "flatten": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+            },
+            "indexes-of": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "vue-hot-reload-api": {
+          "version": "2.1.0",
+          "from": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.1.0.tgz"
+        },
+        "vue-template-compiler": {
+          "version": "2.3.4",
+          "from": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.3.4.tgz",
+          "dependencies": {
+            "he": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
+            },
+            "de-indent": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz"
+            }
+          }
+        },
+        "vue-template-es2015-compiler": {
+          "version": "1.5.2",
+          "from": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.2.tgz"
+        }
+      }
+    },
+    "vue-style-loader": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-1.0.0.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "webpack": {
+      "version": "1.15.0",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        },
+        "async": {
+          "version": "1.5.2",
+          "from": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            }
+          }
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "http://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "resolved": "http://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.11",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.7.0",
+          "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+          "dependencies": {
+            "assert": {
+              "version": "1.4.1",
+              "from": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+              "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.9",
+                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "4.9.1",
+              "from": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.8",
+                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.3.0",
+              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "from": "http://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "http://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "from": "http://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+                  "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                },
+                "browserify-aes": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.7",
+              "from": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+              "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+            },
+            "events": {
+              "version": "1.1.1",
+              "from": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
+            },
+            "https-browserify": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+            },
+            "os-browserify": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.11.10",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "from": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+              "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "2.2.11",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "stream-http": {
+              "version": "2.7.2",
+              "from": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+              "dependencies": {
+                "builtin-status-codes": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "to-arraybuffer": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+              "dependencies": {
+                "setimmediate": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+                }
+              }
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "from": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+        },
+        "uglify-js": {
+          "version": "2.7.5",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.3",
+                      "from": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.2.2",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.5",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "1.0.4",
+                          "from": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                          "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.2.2",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.5",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "http://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "resolved": "http://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "chokidar": {
+              "version": "1.7.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.11",
+                      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.3",
+                              "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                          "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.5",
+                          "from": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                          "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.2",
+                              "from": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                              "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                      "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.1.0",
+                                      "from": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                      "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "1.0.0",
+                                          "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.7",
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "3.0.0",
+                                          "from": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.2.2",
+                                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.5",
+                                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "kind-of": {
+                                          "version": "4.0.0",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.6.1",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                              "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                              "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.5",
+                          "from": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                          "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                          "dependencies": {
+                            "is-posix-bracket": {
+                              "version": "0.1.1",
+                              "from": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                              "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "extglob": {
+                          "version": "0.3.2",
+                          "from": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                          "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.5",
+                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.1.1",
+                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                          "dependencies": {
+                            "remove-trailing-separator": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "object.omit": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.5",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "1.0.2",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                              "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.3",
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.3",
+                          "from": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                          "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                              "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.8.0",
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                },
+                "readdirp": {
+                  "version": "2.1.0",
+                  "from": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.8",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.2.11",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                        },
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "from": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                      "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.9",
+          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.8",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "1.16.5",
+      "from": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
+      "dependencies": {
+        "compression": {
+          "version": "1.6.2",
+          "from": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "2.3.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+            },
+            "compressible": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.28.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.28.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.28.0.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+            },
+            "vary": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+            }
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
+        },
+        "express": {
+          "version": "4.15.3",
+          "from": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "array-flatten": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+            },
+            "content-disposition": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+            },
+            "content-type": {
+              "version": "1.0.2",
+              "from": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "debug": {
+              "version": "2.6.7",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "http://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "encodeurl": {
+              "version": "1.0.1",
+              "from": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "etag": {
+              "version": "1.8.0",
+              "from": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+            },
+            "finalhandler": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+              "dependencies": {
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+            },
+            "methods": {
+              "version": "1.1.2",
+              "from": "http://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "resolved": "http://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "http://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "http://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "http://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.1.4",
+              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "from": "forwarded@0.1.0"
+                },
+                "ipaddr.js": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            },
+            "send": {
+              "version": "0.15.3",
+              "from": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "http://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "resolved": "http://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.6.1",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.12.3",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+            },
+            "statuses": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            },
+            "type-is": {
+              "version": "1.6.15",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vary": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "open": {
+          "version": "0.0.5",
+          "from": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
+        },
+        "serve-index": {
+          "version": "1.9.0",
+          "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "http-errors": {
+              "version": "1.6.1",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "http://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "resolved": "http://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.27.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "http://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "http://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            }
+          }
+        },
+        "sockjs": {
+          "version": "0.3.18",
+          "from": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+          "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+          "dependencies": {
+            "faye-websocket": {
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@0.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+            }
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "eventsource": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+              "dependencies": {
+                "original": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+                  "dependencies": {
+                    "url-parse": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+                      "dependencies": {
+                        "querystringify": {
+                          "version": "0.0.4",
+                          "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
+                        },
+                        "requires-port": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.11.1",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@0.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "json3": {
+              "version": "3.3.2",
+              "from": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+              "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+            },
+            "url-parse": {
+              "version": "1.1.9",
+              "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+              "dependencies": {
+                "querystringify": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
+                },
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "stream-cache": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.10.2",
+          "from": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "from": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "from": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.11",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.6",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            }
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.17.4",
+          "from": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+          "dependencies": {
+            "http-proxy": {
+              "version": "1.16.2",
+              "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+                },
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+                }
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "dependencies": {
+                "arr-diff": {
+                  "version": "2.0.0",
+                  "from": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                  "dependencies": {
+                    "arr-flatten": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+                    }
+                  }
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "from": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                  "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                },
+                "braces": {
+                  "version": "1.8.5",
+                  "from": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                  "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                  "dependencies": {
+                    "expand-range": {
+                      "version": "1.8.2",
+                      "from": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                      "dependencies": {
+                        "fill-range": {
+                          "version": "2.2.3",
+                          "from": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                          "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                          "dependencies": {
+                            "is-number": {
+                              "version": "2.1.0",
+                              "from": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                              "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                            },
+                            "isobject": {
+                              "version": "2.1.0",
+                              "from": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                              "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "randomatic": {
+                              "version": "1.1.7",
+                              "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "3.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.2.2",
+                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.5",
+                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "kind-of": {
+                                  "version": "4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "preserve": {
+                      "version": "0.2.0",
+                      "from": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                      "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                    },
+                    "repeat-element": {
+                      "version": "1.1.2",
+                      "from": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                      "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.5",
+                  "from": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                  "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                  "dependencies": {
+                    "is-posix-bracket": {
+                      "version": "0.1.1",
+                      "from": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                      "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "0.3.2",
+                  "from": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                  "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                },
+                "filename-regex": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                },
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+                },
+                "kind-of": {
+                  "version": "3.2.2",
+                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "dependencies": {
+                    "is-buffer": {
+                      "version": "1.1.5",
+                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                    }
+                  }
+                },
+                "normalize-path": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                  "dependencies": {
+                    "remove-trailing-separator": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                    }
+                  }
+                },
+                "object.omit": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                  "dependencies": {
+                    "for-own": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                      "dependencies": {
+                        "for-in": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "is-extendable": {
+                      "version": "0.1.1",
+                      "from": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                      "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                    }
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "from": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                  "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                  "dependencies": {
+                    "glob-base": {
+                      "version": "0.3.0",
+                      "from": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                      "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                      "dependencies": {
+                        "glob-parent": {
+                          "version": "2.0.0",
+                          "from": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "is-dotfile": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.4.3",
+                  "from": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                  "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                  "dependencies": {
+                    "is-equal-shallow": {
+                      "version": "0.1.3",
+                      "from": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                    },
+                    "is-primitive": {
+                      "version": "2.0.0",
+                      "from": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webpack": {
+          "version": "2.7.0",
+          "from": "webpack@>=1.0.0 <2.0.0||>=2.1.0-beta <3.0.0||>=2.2.0-rc.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "5.1.1",
+              "from": "acorn@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
+            },
+            "acorn-dynamic-import": {
+              "version": "2.0.2",
+              "from": "acorn-dynamic-import@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "4.0.13",
+                  "from": "acorn@>=4.0.3 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+                }
+              }
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "from": "ajv@>=4.7.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "dependencies": {
+                "co": {
+                  "version": "4.6.0",
+                  "from": "co@>=4.6.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ajv-keywords": {
+              "version": "1.5.1",
+              "from": "ajv-keywords@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
+            },
+            "async": {
+              "version": "2.5.0",
+              "from": "async@>=2.1.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
+            },
+            "enhanced-resolve": {
+              "version": "3.3.0",
+              "from": "enhanced-resolve@>=3.3.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            },
+            "interpret": {
+              "version": "1.0.3",
+              "from": "interpret@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
+            },
+            "json-loader": {
+              "version": "0.5.4",
+              "from": "json-loader@>=0.5.4 <0.6.0",
+              "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "loader-runner": {
+              "version": "2.3.0",
+              "from": "loader-runner@>=2.3.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz"
+            },
+            "loader-utils": {
+              "version": "0.2.17",
+              "from": "loader-utils@>=0.2.16 <0.3.0",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+              "dependencies": {
+                "big.js": {
+                  "version": "3.1.3",
+                  "from": "big.js@>=3.1.3 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+                },
+                "emojis-list": {
+                  "version": "2.1.0",
+                  "from": "emojis-list@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            },
+            "memory-fs": {
+              "version": "0.4.1",
+              "from": "memory-fs@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "from": "errno@>=0.1.3 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "from": "prr@>=0.0.0 <0.1.0",
+                      "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "node-libs-browser": {
+              "version": "2.0.0",
+              "from": "node-libs-browser@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+              "dependencies": {
+                "assert": {
+                  "version": "1.4.1",
+                  "from": "assert@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.9",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+                    }
+                  }
+                },
+                "buffer": {
+                  "version": "4.9.1",
+                  "from": "buffer@>=4.3.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+                  "dependencies": {
+                    "base64-js": {
+                      "version": "1.2.1",
+                      "from": "base64-js@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+                    },
+                    "ieee754": {
+                      "version": "1.1.8",
+                      "from": "ieee754@>=1.1.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "constants-browserify": {
+                  "version": "1.0.0",
+                  "from": "constants-browserify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+                },
+                "crypto-browserify": {
+                  "version": "3.11.1",
+                  "from": "crypto-browserify@>=3.11.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+                  "dependencies": {
+                    "browserify-cipher": {
+                      "version": "1.0.0",
+                      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+                      "dependencies": {
+                        "browserify-aes": {
+                          "version": "1.0.6",
+                          "from": "browserify-aes@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                          "dependencies": {
+                            "buffer-xor": {
+                              "version": "1.0.3",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                            },
+                            "cipher-base": {
+                              "version": "1.0.4",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                              "dependencies": {
+                                "safe-buffer": {
+                                  "version": "5.1.1",
+                                  "from": "safe-buffer@>=5.0.1 <6.0.0",
+                                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "browserify-des": {
+                          "version": "1.0.0",
+                          "from": "browserify-des@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                          "dependencies": {
+                            "cipher-base": {
+                              "version": "1.0.4",
+                              "from": "cipher-base@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                              "dependencies": {
+                                "safe-buffer": {
+                                  "version": "5.1.1",
+                                  "from": "safe-buffer@>=5.0.1 <6.0.0",
+                                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                }
+                              }
+                            },
+                            "des.js": {
+                              "version": "1.0.0",
+                              "from": "des.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "evp_bytestokey": {
+                          "version": "1.0.0",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-sign": {
+                      "version": "4.0.4",
+                      "from": "browserify-sign@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.11.7",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "4.0.1",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+                        },
+                        "elliptic": {
+                          "version": "6.4.0",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.1.0",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.1.3",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz"
+                            },
+                            "hmac-drbg": {
+                              "version": "1.0.1",
+                              "from": "hmac-drbg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "minimalistic-assert@>=1.0.0 <2.0.0"
+                            },
+                            "minimalistic-crypto-utils": {
+                              "version": "1.0.1",
+                              "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-asn1": {
+                          "version": "5.1.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "4.9.1",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.6",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.4",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                                  "dependencies": {
+                                    "safe-buffer": {
+                                      "version": "5.1.1",
+                                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-ecdh": {
+                      "version": "4.0.0",
+                      "from": "create-ecdh@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.11.7",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+                        },
+                        "elliptic": {
+                          "version": "6.4.0",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.1.0",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.1.3",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz"
+                            },
+                            "hmac-drbg": {
+                              "version": "1.0.1",
+                              "from": "hmac-drbg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "minimalistic-assert@>=1.0.0 <2.0.0"
+                            },
+                            "minimalistic-crypto-utils": {
+                              "version": "1.0.1",
+                              "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-hash": {
+                      "version": "1.1.3",
+                      "from": "create-hash@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+                      "dependencies": {
+                        "cipher-base": {
+                          "version": "1.0.4",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                          "dependencies": {
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "from": "safe-buffer@>=5.0.1 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                            }
+                          }
+                        },
+                        "ripemd160": {
+                          "version": "2.0.1",
+                          "from": "ripemd160@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+                          "dependencies": {
+                            "hash-base": {
+                              "version": "2.0.2",
+                              "from": "hash-base@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+                            }
+                          }
+                        },
+                        "sha.js": {
+                          "version": "2.4.8",
+                          "from": "sha.js@>=2.4.8 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+                        }
+                      }
+                    },
+                    "create-hmac": {
+                      "version": "1.1.6",
+                      "from": "create-hmac@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+                      "dependencies": {
+                        "cipher-base": {
+                          "version": "1.0.4",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz"
+                        },
+                        "ripemd160": {
+                          "version": "2.0.1",
+                          "from": "ripemd160@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+                          "dependencies": {
+                            "hash-base": {
+                              "version": "2.0.2",
+                              "from": "hash-base@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+                            }
+                          }
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "from": "safe-buffer@>=5.0.1 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                        },
+                        "sha.js": {
+                          "version": "2.4.8",
+                          "from": "sha.js@>=2.4.8 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+                        }
+                      }
+                    },
+                    "diffie-hellman": {
+                      "version": "5.0.2",
+                      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.11.7",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+                        },
+                        "miller-rabin": {
+                          "version": "4.0.0",
+                          "from": "miller-rabin@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.1.0",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "pbkdf2": {
+                      "version": "3.0.12",
+                      "from": "pbkdf2@>=3.0.3 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+                      "dependencies": {
+                        "ripemd160": {
+                          "version": "2.0.1",
+                          "from": "ripemd160@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+                          "dependencies": {
+                            "hash-base": {
+                              "version": "2.0.2",
+                              "from": "hash-base@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+                            }
+                          }
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "from": "safe-buffer@>=5.0.1 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                        },
+                        "sha.js": {
+                          "version": "2.4.8",
+                          "from": "sha.js@>=2.4.8 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+                        }
+                      }
+                    },
+                    "public-encrypt": {
+                      "version": "4.0.0",
+                      "from": "public-encrypt@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.11.7",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "4.0.1",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+                        },
+                        "parse-asn1": {
+                          "version": "5.1.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "4.9.1",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.6",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.4",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                                  "dependencies": {
+                                    "safe-buffer": {
+                                      "version": "5.1.1",
+                                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "randombytes": {
+                      "version": "2.0.5",
+                      "from": "randombytes@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+                      "dependencies": {
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "from": "safe-buffer@>=5.1.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domain-browser": {
+                  "version": "1.1.7",
+                  "from": "domain-browser@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+                },
+                "events": {
+                  "version": "1.1.1",
+                  "from": "events@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
+                },
+                "https-browserify": {
+                  "version": "0.0.1",
+                  "from": "https-browserify@0.0.1",
+                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+                },
+                "os-browserify": {
+                  "version": "0.2.1",
+                  "from": "os-browserify@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+                },
+                "path-browserify": {
+                  "version": "0.0.0",
+                  "from": "path-browserify@0.0.0",
+                  "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+                },
+                "process": {
+                  "version": "0.11.10",
+                  "from": "process@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.2.4 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                },
+                "querystring-es3": {
+                  "version": "0.2.1",
+                  "from": "querystring-es3@>=0.2.0 <0.3.0",
+                  "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "stream-browserify": {
+                  "version": "2.0.1",
+                  "from": "stream-browserify@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "stream-http": {
+                  "version": "2.7.2",
+                  "from": "stream-http@>=2.3.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+                  "dependencies": {
+                    "builtin-status-codes": {
+                      "version": "3.0.0",
+                      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "to-arraybuffer": {
+                      "version": "1.0.1",
+                      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.25 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "timers-browserify": {
+                  "version": "2.0.2",
+                  "from": "timers-browserify@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+                  "dependencies": {
+                    "setimmediate": {
+                      "version": "1.0.5",
+                      "from": "setimmediate@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+                    }
+                  }
+                },
+                "tty-browserify": {
+                  "version": "0.0.0",
+                  "from": "tty-browserify@0.0.0",
+                  "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+                },
+                "url": {
+                  "version": "0.11.0",
+                  "from": "url@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@1.3.2",
+                      "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    },
+                    "querystring": {
+                      "version": "0.2.0",
+                      "from": "querystring@0.2.0",
+                      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                    }
+                  }
+                },
+                "util": {
+                  "version": "0.10.3",
+                  "from": "util@>=0.10.3 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "vm-browserify": {
+                  "version": "0.0.4",
+                  "from": "vm-browserify@0.0.4",
+                  "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                  "dependencies": {
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.3 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "tapable": {
+              "version": "0.2.6",
+              "from": "tapable@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "from": "uglify-js@>=2.8.27 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            },
+            "watchpack": {
+              "version": "1.4.0",
+              "from": "watchpack@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+              "dependencies": {
+                "chokidar": {
+                  "version": "1.7.0",
+                  "from": "chokidar@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+                  "dependencies": {
+                    "anymatch": {
+                      "version": "1.3.0",
+                      "from": "anymatch@>=1.3.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                      "dependencies": {
+                        "arrify": {
+                          "version": "1.0.1",
+                          "from": "arrify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                        },
+                        "micromatch": {
+                          "version": "2.3.11",
+                          "from": "micromatch@>=2.1.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                          "dependencies": {
+                            "arr-diff": {
+                              "version": "2.0.0",
+                              "from": "arr-diff@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                              "dependencies": {
+                                "arr-flatten": {
+                                  "version": "1.1.0",
+                                  "from": "arr-flatten@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "array-unique": {
+                              "version": "0.2.1",
+                              "from": "array-unique@>=0.2.1 <0.3.0",
+                              "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                            },
+                            "braces": {
+                              "version": "1.8.5",
+                              "from": "braces@>=1.8.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                              "dependencies": {
+                                "expand-range": {
+                                  "version": "1.8.2",
+                                  "from": "expand-range@>=1.8.1 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                                  "dependencies": {
+                                    "fill-range": {
+                                      "version": "2.2.3",
+                                      "from": "fill-range@>=2.1.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "2.1.0",
+                                          "from": "is-number@>=2.1.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                        },
+                                        "isobject": {
+                                          "version": "2.1.0",
+                                          "from": "isobject@>=2.0.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                          "dependencies": {
+                                            "isarray": {
+                                              "version": "1.0.0",
+                                              "from": "isarray@1.0.0",
+                                              "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "randomatic": {
+                                          "version": "1.1.7",
+                                          "from": "randomatic@>=1.1.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                          "dependencies": {
+                                            "is-number": {
+                                              "version": "3.0.0",
+                                              "from": "is-number@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                              "dependencies": {
+                                                "kind-of": {
+                                                  "version": "3.2.2",
+                                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                                  "dependencies": {
+                                                    "is-buffer": {
+                                                      "version": "1.1.5",
+                                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "kind-of": {
+                                              "version": "4.0.0",
+                                              "from": "kind-of@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.5",
+                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.6.1",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preserve": {
+                                  "version": "0.2.0",
+                                  "from": "preserve@>=0.2.0 <0.3.0",
+                                  "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                                },
+                                "repeat-element": {
+                                  "version": "1.1.2",
+                                  "from": "repeat-element@>=1.1.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "expand-brackets": {
+                              "version": "0.1.5",
+                              "from": "expand-brackets@>=0.1.4 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                              "dependencies": {
+                                "is-posix-bracket": {
+                                  "version": "0.1.1",
+                                  "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                                  "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "extglob": {
+                              "version": "0.3.2",
+                              "from": "extglob@>=0.3.1 <0.4.0",
+                              "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                            },
+                            "filename-regex": {
+                              "version": "2.0.1",
+                              "from": "filename-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                            },
+                            "is-extglob": {
+                              "version": "1.0.0",
+                              "from": "is-extglob@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                            },
+                            "kind-of": {
+                              "version": "3.2.2",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.5",
+                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                }
+                              }
+                            },
+                            "normalize-path": {
+                              "version": "2.1.1",
+                              "from": "normalize-path@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                              "dependencies": {
+                                "remove-trailing-separator": {
+                                  "version": "1.0.2",
+                                  "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "object.omit": {
+                              "version": "2.0.1",
+                              "from": "object.omit@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                              "dependencies": {
+                                "for-own": {
+                                  "version": "0.1.5",
+                                  "from": "for-own@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                                  "dependencies": {
+                                    "for-in": {
+                                      "version": "1.0.2",
+                                      "from": "for-in@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "is-extendable": {
+                                  "version": "0.1.1",
+                                  "from": "is-extendable@>=0.1.1 <0.2.0",
+                                  "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "parse-glob": {
+                              "version": "3.0.4",
+                              "from": "parse-glob@>=3.0.4 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.3.0",
+                                  "from": "glob-base@>=0.3.0 <0.4.0",
+                                  "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                                },
+                                "is-dotfile": {
+                                  "version": "1.0.3",
+                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                                }
+                              }
+                            },
+                            "regex-cache": {
+                              "version": "0.4.3",
+                              "from": "regex-cache@>=0.4.2 <0.5.0",
+                              "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                              "dependencies": {
+                                "is-equal-shallow": {
+                                  "version": "0.1.3",
+                                  "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                                  "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                                },
+                                "is-primitive": {
+                                  "version": "2.0.0",
+                                  "from": "is-primitive@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "async-each": {
+                      "version": "1.0.1",
+                      "from": "async-each@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+                    },
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "from": "glob-parent@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "is-binary-path": {
+                      "version": "1.0.1",
+                      "from": "is-binary-path@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                      "dependencies": {
+                        "binary-extensions": {
+                          "version": "1.8.0",
+                          "from": "binary-extensions@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+                        }
+                      }
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "from": "is-glob@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                      "dependencies": {
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    },
+                    "readdirp": {
+                      "version": "2.1.0",
+                      "from": "readdirp@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "from": "minimatch@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.8",
+                              "from": "brace-expansion@>=1.1.7 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "from": "balanced-match@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.3.3",
+                          "from": "readable-stream@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "from": "safe-buffer@>=5.1.1 <5.2.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "1.0.3",
+                              "from": "string_decoder@>=1.0.3 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "set-immediate-shim": {
+                          "version": "1.0.1",
+                          "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                }
+              }
+            },
+            "webpack-sources": {
+              "version": "1.0.1",
+              "from": "webpack-sources@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+              "dependencies": {
+                "source-list-map": {
+                  "version": "2.0.0",
+                  "from": "source-list-map@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz"
+                }
+              }
+            },
+            "yargs": {
+              "version": "6.6.0",
+              "from": "yargs@>=6.0.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "3.0.0",
+                  "from": "camelcase@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "from": "cliui@>=3.2.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "dependencies": {
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "from": "get-caller-file@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "from": "os-locale@>=1.4.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "from": "lcid@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.1.0",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.11",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.1",
+                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "normalize-package-data": {
+                          "version": "2.4.0",
+                          "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.5.0",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.3.0",
+                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.2",
+                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.4",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.11",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "from": "require-directory@>=2.1.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "from": "require-main-filename@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "from": "set-blocking@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "from": "string-width@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "1.0.0",
+                  "from": "which-module@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "from": "y18n@>=3.2.1 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                },
+                "yargs-parser": {
+                  "version": "4.2.1",
+                  "from": "yargs-parser@>=4.2.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "version": "1.5.0",
   "main": "lib/index.js",
   "scripts": {
-    "install": "napa 'd3/d3-plugins:d3-plugins'",
     "start": "xdg-open index.html",
     "build:lib": "gulp",
     "build:dist": "webpack --hide-modules --config webpack.config.development.js",
@@ -28,9 +27,9 @@
     "bubbletree": "git+https://github.com/okfn/bubbletree.git",
     "c3": "git+https://github.com/masayuki0812/c3.git",
     "d3": "^3.5.16",
+    "d3-plugins-sankey-fixed": "^1.3.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.5.1",
-    "napa": "^2.3.0",
     "pivottable": "git+https://github.com/nicolaskruchten/pivottable.git",
     "raphael": "^2.1.4"
   },

--- a/src/components/sankey/index.js
+++ b/src/components/sankey/index.js
@@ -1,6 +1,6 @@
 import { Api } from '../../api/index'
 import d3 from 'd3'
-import 'd3-plugins/sankey/sankey'
+import 'd3-plugins-sankey-fixed'
 import * as Utils from '../utils.js'
 import _ from 'lodash'
 import events from 'events'


### PR DESCRIPTION
We have to stop using `napa` because it isn't compatible with `npm-shrinkwrap`,
which means none of the apps that use `babbage.ui` can use `npm-shrinkwrap`,
even if they don't use `napa` themselves.

openspending/openspending#1264