### PR TITLE
[#1198] Allow changing BubbleTree's colours through `getStyle()` option

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3274,9 +3274,9 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bubbletree": {
-      "version": "2.0.4",
-      "from": "git+https://github.com/okfn/bubbletree.git#d797bff3ef22d22951acf6f55a83f6555d7a801a",
-      "resolved": "git+https://github.com/okfn/bubbletree.git#d797bff3ef22d22951acf6f55a83f6555d7a801a",
+      "version": "2.1.0",
+      "from": "git+https://github.com/okfn/bubbletree.git#1b16bc3934c494e32e0bff0fb2936a89770019aa",
+      "resolved": "git+https://github.com/okfn/bubbletree.git#1b16bc3934c494e32e0bff0fb2936a89770019aa",
       "dependencies": {
         "jquery": {
           "version": "1.12.4",

--- a/src/bindings/angular/bubbletree/index.js
+++ b/src/bindings/angular/bubbletree/index.js
@@ -16,7 +16,8 @@ export class BubbleTreeDirective {
             state: '=',
             downloader: '=?',
             formatValue: '=?',
-            messages: '=?'
+            messages: '=?',
+            getStyle: '=?'
           },
           template: require('./template.html'),
           replace: false,
@@ -42,6 +43,7 @@ export class BubbleTreeDirective {
             let wrapper = element.find('.bubbletree')[0];
 
             component.formatValue = $scope.formatValue;
+            component.getStyle = $scope.getStyle;
             component.on('loading', () => {
               $scope.status.isLoading = true;
               $scope.status.isEmpty = false;

--- a/src/components/bubbletree/index.js
+++ b/src/components/bubbletree/index.js
@@ -16,6 +16,7 @@ export class BubbleTreeComponent extends events.EventEmitter {
     this.bubbleTree = null;
     this.downloader = null;
     this.formatValue = null;
+    this.getStyle = () => ({});
 
     // Prevent from throwing exception in EventEmitter
     this.on('error', (sender, error) => {
@@ -93,6 +94,9 @@ export class BubbleTreeComponent extends events.EventEmitter {
             data: bubbleTreeData,
             container: wrapper,
             formatValue: valueFormat,
+            bubbleStyles: {
+              getStyle: that.getStyle
+            },
             nodeClickCallback: (node) => {
               if (node.level > 0) {
                 that.emit('click', that, node);

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
 var _ = require('lodash');
 
 module.exports = {
@@ -17,6 +18,9 @@ module.exports = {
     libraryTarget: 'umd'
   },
   devtool: 'source-map',
+  resolve: {
+    fallback: path.join(__dirname, 'node_modules'),
+  },
   externals: {
     // require("jquery") is external and available
     // on the global var jQuery


### PR DESCRIPTION
_WARNING: Wait until the `bubbletree` PR is merged before merging this, and then
also update the `npm-shrinkwrap.json` file to get the latest version from
`bubbletree`_

This new parameter was implemented on https://github.com/okfn/bubbletree/pull/51
and allows passing a callback method to BubbleTree which would be called with
`node` and `index`, and can return a new `color`, `icon` and `shortLabel`.

openspending/openspending#1198