### PR TITLE
Handle server errors when downloading datasets

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -16,7 +16,12 @@ export class Api {
 
   getJson(url) {
     var downloader = this.downloader || getDefaultDownloader();
-    return downloader.getJson(url);
+    return downloader.getJson(url).then(function(result){
+      if (result.status == 'error') {
+        throw new Error(result.message);
+      }
+      return result;
+    });
   }
 
   flush() {
@@ -239,7 +244,9 @@ export class Api {
       });
       exportResults('facts', result);
       return result;
-    })
+    }).catch(function(error) {
+      throw error;
+    });
   }
 
   buildAggregateUrl(endpoint, cube, originParams) {
@@ -346,6 +353,8 @@ export class Api {
       });
       exportResults('aggregate', result);
       return result;
+    }).catch(function(error) {
+      throw error;
     });
   }
 

--- a/src/bindings/angular/bubbletree/index.js
+++ b/src/bindings/angular/bubbletree/index.js
@@ -25,6 +25,7 @@ export class BubbleTreeDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -55,6 +56,8 @@ export class BubbleTreeDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/bubbletree/template.html
+++ b/src/bindings/angular/bubbletree/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/bubbletree/template.html
+++ b/src/bindings/angular/bubbletree/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/chart/index.js
+++ b/src/bindings/angular/chart/index.js
@@ -25,6 +25,7 @@ export class ChartDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -55,6 +56,8 @@ export class ChartDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/chart/template.html
+++ b/src/bindings/angular/chart/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/chart/template.html
+++ b/src/bindings/angular/chart/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/facts/index.js
+++ b/src/bindings/angular/facts/index.js
@@ -23,6 +23,7 @@ export class FactsDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -96,6 +97,8 @@ export class FactsDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.columns.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/facts/template.html
+++ b/src/bindings/angular/facts/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/facts/template.html
+++ b/src/bindings/angular/facts/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div ng-if="!status.isEmpty">
   <div class="table-babbage">
     <table class="table table-bordered table-condensed">

--- a/src/bindings/angular/geoview/index.js
+++ b/src/bindings/angular/geoview/index.js
@@ -30,6 +30,7 @@ export class GeoViewDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -58,6 +59,8 @@ export class GeoViewDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
             });
 

--- a/src/bindings/angular/geoview/template.html
+++ b/src/bindings/angular/geoview/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/geoview/template.html
+++ b/src/bindings/angular/geoview/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/pie/index.js
+++ b/src/bindings/angular/pie/index.js
@@ -26,6 +26,7 @@ export class PieChartDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -53,9 +54,11 @@ export class PieChartDirective {
             });
             component.on('ready', (component, data, error) => {
               $scope.status.isLoading = false;
-              $scope.status.isEmpty = !(_.isObject(data) &&
-                (data.cells.length > 0));
+              $scope.status.isEmpty = !(_.isObject(data)
+                     && (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/pie/template.html
+++ b/src/bindings/angular/pie/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/pie/template.html
+++ b/src/bindings/angular/pie/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/pivottable/index.js
+++ b/src/bindings/angular/pivottable/index.js
@@ -28,6 +28,7 @@ export class PivotTableDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -56,6 +57,8 @@ export class PivotTableDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/pivottable/template.html
+++ b/src/bindings/angular/pivottable/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('chooseRowsAndColumns'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/pivottable/template.html
+++ b/src/bindings/angular/pivottable/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('chooseRowsAndColumns'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/radar/index.js
+++ b/src/bindings/angular/radar/index.js
@@ -24,6 +24,7 @@ export class RadarChartDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -54,6 +55,8 @@ export class RadarChartDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.data.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/radar/template.html
+++ b/src/bindings/angular/radar/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/radar/template.html
+++ b/src/bindings/angular/radar/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/sankey/index.js
+++ b/src/bindings/angular/sankey/index.js
@@ -24,6 +24,7 @@ export class SanKeyChartDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -53,6 +54,8 @@ export class SanKeyChartDirective {
               $scope.status.isLoading = false;
               $scope.status.isEmpty = !(_.isObject(data) && (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/sankey/template.html
+++ b/src/bindings/angular/sankey/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/sankey/template.html
+++ b/src/bindings/angular/sankey/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/table/index.js
+++ b/src/bindings/angular/table/index.js
@@ -23,6 +23,7 @@ export class BabbageTableDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -56,6 +57,8 @@ export class BabbageTableDirective {
               $scope.status.isEmpty = !(_.isObject(data) &&
                 (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/table/template.html
+++ b/src/bindings/angular/table/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/table/template.html
+++ b/src/bindings/angular/table/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="table-babbage" ng-if="!status.isEmpty">
   <table class="table table-bordered table-condensed">
     <thead>

--- a/src/bindings/angular/treemap/index.js
+++ b/src/bindings/angular/treemap/index.js
@@ -25,6 +25,7 @@ class TreemapDirective {
             $scope.status = {
               isLoading: true,
               isEmpty: false,
+              hasError: false,
               isCutOff: false,
               cutoff: 0
             };
@@ -78,6 +79,8 @@ class TreemapDirective {
               $scope.status.isLoading = false;
               $scope.status.isEmpty = !(_.isObject(data) && (data.cells.length > 0));
               $scope.status.isCutOff = false;
+              $scope.status.hasError = !!error;
+              $scope.error = !!error && error.message;
               $scope.$applyAsync();
               $scope.$emit('babbage-ui.ready', component, data, error);
             });

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -2,7 +2,7 @@
   <i class="babbage-loading-icon"></i><span ng-bind-html="trustAsHtml(i18n('loadingData'))"></span>
 </div>
 
-<div class="alert alert-warning" ng-if="status.isEmpty"
+<div class="alert alert-warning" ng-if="status.isEmpty && status.hasError == false"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
 <div class="alert alert-warning" ng-if="status.hasError"

--- a/src/bindings/angular/treemap/template.html
+++ b/src/bindings/angular/treemap/template.html
@@ -5,6 +5,9 @@
 <div class="alert alert-warning" ng-if="status.isEmpty"
   ng-bind-html="trustAsHtml(i18n('noDataAvailable'))"></div>
 
+<div class="alert alert-warning" ng-if="status.hasError"
+  ng-bind-html="trustAsHtml(i18n('serverError', {error: error}))"></div>
+
 <div class="alert alert-warning" ng-if="status.isCutOff"
   ng-bind-html="trustAsHtml(i18n('tooManyCategories', {count: status.cutoff}))"></div>
 

--- a/src/bindings/angular/utils/index.js
+++ b/src/bindings/angular/utils/index.js
@@ -21,6 +21,7 @@ export const defaultI18NMessages = {
   percentage: 'Share',
   total: 'Total',
   others: 'Others',
+  serverError: '<strong>{error}</strong>'
 };
 
 function getValueOrDefault(value, defaultValue) {

--- a/src/components/pie/index.js
+++ b/src/components/pie/index.js
@@ -123,6 +123,7 @@ export class PieChartComponent extends events.EventEmitter {
       .catch((error) => {
         that.emit('error', that, error);
         that.emit('ready', that, null, error);
+        throw error;
       });
   }
 

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -88,6 +88,7 @@ export class TableComponent extends events.EventEmitter {
       .catch((error) => {
         that.emit('error', that, error);
         that.emit('ready', that, null, error);
+        throw error;
       });
   }
 


### PR DESCRIPTION
* new flag `hasError` to determine if there was any error in downloader
* new i18n message containing the raw error message
* amended all components/directives and their templates to display server errors

Depends on PR openspending/os-viewer#186 (to throw the raw, unformatted error).
Tracked by issue openspending/openspending#1402.